### PR TITLE
feat(forms): introduces CreateForm and CreateFormFields utilities

### DIFF
--- a/src/components/Form/CreateForm.js
+++ b/src/components/Form/CreateForm.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Form from 'components/Form';
+import CreateFormFields, {
+  formFieldPropTypes,
+} from 'components/Form/CreateFormFields';
+
+function CreateForm({
+  buttonLabel,
+  disabled,
+  description,
+  formFields,
+  onSubmit,
+  otherContent,
+  title,
+}) {
+  return (
+    <Form
+      buttonLabel={buttonLabel || 'Submit'}
+      onSubmit={onSubmit}
+      title={title}
+      disabled={disabled}
+      description={description}
+    >
+      {CreateFormFields(formFields)}
+      {otherContent}
+    </Form>
+  );
+}
+
+CreateForm.propTypes = {
+  buttonLabel: PropTypes.string,
+  description: PropTypes.string,
+  disabled: PropTypes.bool,
+  formFields: PropTypes.arrayOf(
+    PropTypes.shape({
+      formFieldPropTypes,
+    }),
+  ).isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  otherContent: PropTypes.object,
+  title: PropTypes.string,
+};
+
+export default CreateForm;

--- a/src/components/Form/CreateFormFields.js
+++ b/src/components/Form/CreateFormFields.js
@@ -15,7 +15,7 @@ const inputMap = {
 };
 
 function CreateFormFields(data) {
-  const formFields = data.map(({ isHalfWidth, type, ...rest }) => {
+  const formFields = data.map(({ type, ...rest }) => {
     const InputEl = inputMap[type];
 
     return <InputEl key={rest.label} {...rest} />;

--- a/src/components/Form/CreateFormFields.js
+++ b/src/components/Form/CreateFormFields.js
@@ -9,6 +9,16 @@ export const formFieldTypes = {
   INPUT_TEXT: 'INPUT_TEXT',
 };
 
+export const formFieldPropTypes = {
+  customOnChange: PropTypes.func,
+  isHalfWidth: PropTypes.bool,
+  label: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(formFieldTypes)).isRequired,
+  options: PropTypes.array,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+};
+
 const inputMap = {
   [formFieldTypes.INPUT_DROPDOWN]: InputDropdown,
   [formFieldTypes.INPUT_TEXT]: InputText,
@@ -27,13 +37,7 @@ function CreateFormFields(data) {
 CreateFormFields.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
-      customOnChange: PropTypes.func,
-      isHalfWidth: PropTypes.bool,
-      label: PropTypes.string,
-      type: PropTypes.oneOf(Object.values(formFieldTypes)).isRequired,
-      options: PropTypes.array,
-      placeholder: PropTypes.string,
-      value: PropTypes.string,
+      formFieldPropTypes,
     }),
   ).isRequired,
 };

--- a/src/components/Form/CreateFormFields.js
+++ b/src/components/Form/CreateFormFields.js
@@ -12,10 +12,12 @@ export const formFieldTypes = {
 export const formFieldPropTypes = {
   customOnChange: PropTypes.func,
   isHalfWidth: PropTypes.bool,
+  isRequired: PropTypes.bool,
   label: PropTypes.string,
-  type: PropTypes.oneOf(Object.values(formFieldTypes)).isRequired,
+  name: PropTypes.string.isRequired,
   options: PropTypes.array,
   placeholder: PropTypes.string,
+  type: PropTypes.oneOf(Object.values(formFieldTypes)).isRequired,
   value: PropTypes.string,
 };
 
@@ -24,8 +26,8 @@ const inputMap = {
   [formFieldTypes.INPUT_TEXT]: InputText,
 };
 
-function CreateFormFields(data) {
-  const formFields = data.map(({ type, ...rest }) => {
+function CreateFormFields(fields) {
+  const formFields = fields.map(({ type, ...rest }) => {
     const InputEl = inputMap[type];
 
     return <InputEl key={rest.label} {...rest} />;
@@ -35,7 +37,7 @@ function CreateFormFields(data) {
 }
 
 CreateFormFields.propTypes = {
-  data: PropTypes.arrayOf(
+  fields: PropTypes.arrayOf(
     PropTypes.shape({
       formFieldPropTypes,
     }),

--- a/src/components/Form/CreateFormFields.js
+++ b/src/components/Form/CreateFormFields.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import InputText from 'components/InputText';
+import InputDropdown from 'components/InputDropdown';
+
+export const formFieldTypes = {
+  INPUT_DROPDOWN: 'INPUT_DROPDOWN',
+  INPUT_TEXT: 'INPUT_TEXT',
+};
+
+const inputMap = {
+  [formFieldTypes.INPUT_DROPDOWN]: InputDropdown,
+  [formFieldTypes.INPUT_TEXT]: InputText,
+};
+
+function CreateFormFields(data) {
+  const formFields = data.map(({ isHalfWidth, type, ...rest }) => {
+    const InputEl = inputMap[type];
+
+    return <InputEl key={rest.label} {...rest} />;
+  });
+
+  return formFields;
+}
+
+CreateFormFields.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      customOnChange: PropTypes.func,
+      isHalfWidth: PropTypes.bool,
+      label: PropTypes.string,
+      type: PropTypes.oneOf(Object.values(formFieldTypes)).isRequired,
+      options: PropTypes.array,
+      placeholder: PropTypes.string,
+      value: PropTypes.string,
+    }),
+  ).isRequired,
+};
+
+export default CreateFormFields;

--- a/src/components/Form/Form.styles.js
+++ b/src/components/Form/Form.styles.js
@@ -5,6 +5,11 @@ const styles = {
   back: css({
     marginBottom: Space.S30,
   }),
+  childWrapper: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    justifyContent: 'space-between',
+  }),
   sections: css({
     '> *': {
       marginBottom: Space.S30,

--- a/src/components/Form/FormBuilder.js
+++ b/src/components/Form/FormBuilder.js
@@ -6,41 +6,44 @@ import CreateFormFields, {
   formFieldPropTypes,
 } from 'components/Form/CreateFormFields';
 
-function CreateForm({
+function FormBuilder({
   buttonLabel,
-  disabled,
+  children,
+  defaultValues,
   description,
-  formFields,
+  disabled,
+  fields,
   onSubmit,
-  otherContent,
   title,
 }) {
   return (
     <Form
       buttonLabel={buttonLabel || 'Submit'}
+      defaultValues={defaultValues}
       onSubmit={onSubmit}
       title={title}
       disabled={disabled}
       description={description}
     >
-      {CreateFormFields(formFields)}
-      {otherContent}
+      {CreateFormFields(fields)}
+      {children}
     </Form>
   );
 }
 
-CreateForm.propTypes = {
+FormBuilder.propTypes = {
   buttonLabel: PropTypes.string,
+  children: PropTypes.object,
+  defaultValues: PropTypes.object,
   description: PropTypes.string,
   disabled: PropTypes.bool,
-  formFields: PropTypes.arrayOf(
+  fields: PropTypes.arrayOf(
     PropTypes.shape({
-      formFieldPropTypes,
+      ...formFieldPropTypes,
     }),
   ).isRequired,
   onSubmit: PropTypes.func.isRequired,
-  otherContent: PropTypes.object,
   title: PropTypes.string,
 };
 
-export default CreateForm;
+export default FormBuilder;

--- a/src/components/Form/FormBuilder.js
+++ b/src/components/Form/FormBuilder.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 
 import Form from 'components/Form';
 import CreateFormFields, {
@@ -16,9 +17,11 @@ function FormBuilder({
   onSubmit,
   title,
 }) {
+  const { t } = useTranslation();
+
   return (
     <Form
-      buttonLabel={buttonLabel || 'Submit'}
+      buttonLabel={buttonLabel || t('generic.form.submitLabel')}
       defaultValues={defaultValues}
       onSubmit={onSubmit}
       title={title}

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -39,7 +39,7 @@ const Form = ({
           css={styles.button}
         >
           <Text type={TEXT_TYPE.BODY_1}>
-            {buttonLabel || t('generic.form.submitLabel')}
+            {buttonLabel || t('generic.form.submitLabelNext')}
           </Text>
         </PrimaryButton>
       </form>

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -10,7 +10,7 @@ import { useForm, FormContext } from 'react-hook-form';
 
 import styles from './Form.styles.js';
 
-export const Form = ({
+const Form = ({
   buttonLabel,
   children,
   defaultValues,

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -30,7 +30,7 @@ export const Form = ({
       <form onSubmit={methods.handleSubmit(onSubmit)} css={styles.root}>
         <div css={styles.sections}>
           <HeaderInfo {...{ title, description }} />
-          {children}
+          <div css={styles.childWrapper}>{children}</div>
         </div>
         <PrimaryButton
           type="submit"

--- a/src/components/InputDropdown/InputDropdown.styles.js
+++ b/src/components/InputDropdown/InputDropdown.styles.js
@@ -42,7 +42,9 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     height: Height.INPUT,
+    margin: `0 0 ${Space.S30}px 0`,
     position: 'relative',
+    width: '100%',
 
     '&:focus-within': {
       borderColor: Color.CORAL_30,
@@ -53,6 +55,9 @@ const styles = {
 
       '& div': activeLabel,
     },
+  }),
+  rootHalfWidth: css({
+    width: 'calc(50% - 8px)',
   }),
   select: css({
     ...selectReset,

--- a/src/components/InputDropdown/index.js
+++ b/src/components/InputDropdown/index.js
@@ -15,6 +15,7 @@ const DEFAULT = 'placeholder';
 function InputDropdown({
   customOnChange,
   inputProps,
+  isHalfWidth,
   options = [],
   name,
   label,
@@ -32,8 +33,9 @@ function InputDropdown({
     },
     [customOnChange, setValue],
   );
+
   return (
-    <div css={styles.root}>
+    <div css={[styles.root, isHalfWidth && styles.rootHalfWidth]}>
       {label && (
         <div css={[styles.label, value !== DEFAULT && styles.activeLabel]}>
           {label}

--- a/src/components/InputText/InputText.styles.js
+++ b/src/components/InputText/InputText.styles.js
@@ -10,6 +10,15 @@ const styles = {
     paddingTop: Space.S10,
     transition: '0.2s all ease-in-out',
   }),
+  container: css({
+    display: 'flex',
+    border: Borders.TRANSPARENT,
+    borderRadius: Radius.ROUNDED,
+    flexDirection: 'column',
+    height: Height.INPUT,
+    margin: 0,
+    width: '100%',
+  }),
   error: css({
     color: Color.CORAL,
     position: 'absolute',
@@ -52,11 +61,6 @@ const styles = {
     transition: '0.2s all ease-in-out',
   }),
   root: css({
-    display: 'flex',
-    border: Borders.TRANSPARENT,
-    borderRadius: Radius.ROUNDED,
-    flexDirection: 'column',
-    height: Height.INPUT,
     margin: `0 0 ${Space.S30}px 0`,
     position: 'relative',
     width: '100%',

--- a/src/components/InputText/InputText.styles.js
+++ b/src/components/InputText/InputText.styles.js
@@ -57,7 +57,12 @@ const styles = {
     borderRadius: Radius.ROUNDED,
     flexDirection: 'column',
     height: Height.INPUT,
+    margin: `0 0 ${Space.S30}px 0`,
     position: 'relative',
+    width: '100%',
+  }),
+  rootHalfWidth: css({
+    width: 'calc(50% - 8px)',
   }),
 };
 

--- a/src/components/InputText/index.js
+++ b/src/components/InputText/index.js
@@ -13,6 +13,7 @@ function InputText({
   customOnChange,
   name,
   label,
+  isHalfWidth,
   isRequired = true,
   value: initialValue,
   validation,
@@ -38,7 +39,13 @@ function InputText({
 
   return (
     <div>
-      <label css={[styles.root, isFocused && styles.active]}>
+      <label
+        css={[
+          styles.root,
+          isFocused && styles.active,
+          isHalfWidth && styles.rootHalfWidth,
+        ]}
+      >
         {label && (
           <div css={[styles.label, (isFocused || value) && styles.activeLabel]}>
             {label}

--- a/src/components/InputText/index.js
+++ b/src/components/InputText/index.js
@@ -38,14 +38,8 @@ function InputText({
   }, []);
 
   return (
-    <div>
-      <label
-        css={[
-          styles.root,
-          isFocused && styles.active,
-          isHalfWidth && styles.rootHalfWidth,
-        ]}
-      >
+    <div css={[styles.root, isHalfWidth && styles.rootHalfWidth]}>
+      <label css={[styles.container, isFocused && styles.active]}>
         {label && (
           <div css={[styles.label, (isFocused || value) && styles.activeLabel]}>
             {label}

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -6,14 +6,16 @@ import { jsx } from '@emotion/core';
 import { Emails } from 'constants/Emails';
 import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
+import states from 'data/states';
 
 import Form from 'components/Form';
-import InputText from 'components/InputText';
-import InputDropdown from 'components/InputDropdown';
 import Anchor from 'components/Anchor';
 import Note from 'components/Note';
-import states from 'data/states';
 import FacilityConfirmation from 'components/FacilityConfirmation';
+
+import CreateFormFields, {
+  formFieldTypes,
+} from 'components/Form/CreateFormFields';
 
 function FacilityForm({ backend, history }) {
   const { t } = useTranslation();
@@ -88,6 +90,55 @@ function FacilityForm({ backend, history }) {
     );
   }
 
+  const formFieldsData = [
+    {
+      customOnChange: handleFieldChange('dropSiteFacilityName'),
+      label: t('request.facilityForm.dropSiteFacilityName.label'),
+      name: 'name',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteFacilityName,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteZip'),
+      label: t('request.facilityForm.dropSiteZip.label'),
+      name: 'zip',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteZip,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteCity'),
+      isHalfWidth: true,
+      label: t('request.facilityForm.dropSiteCity.label'),
+      name: 'city',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteCity,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteState'),
+      isHalfWidth: true,
+      label: t('request.facilityForm.dropSiteState.label'),
+      options: states,
+      name: 'state',
+      type: formFieldTypes.INPUT_DROPDOWN,
+      value: dropSiteState,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteAddress'),
+      label: t('request.facilityForm.dropSiteAddress.label'),
+      name: 'address',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteAddress,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteUrl'),
+      isRequired: false,
+      label: t('request.facilityForm.dropSiteUrl.label'),
+      name: 'url',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteUrl,
+    },
+  ];
+
   return (
     <Form
       defaultValues={fields}
@@ -97,46 +148,7 @@ function FacilityForm({ backend, history }) {
       disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
       description={t('request.facilityForm.description')}
     >
-      <InputText
-        name="name"
-        label={t('request.facilityForm.dropSiteFacilityName.label')}
-        value={dropSiteFacilityName}
-        customOnChange={handleFieldChange('dropSiteFacilityName')}
-      />
-      <InputText
-        name="zip"
-        label={t('request.facilityForm.dropSiteZip.label')}
-        value={dropSiteZip}
-        customOnChange={handleFieldChange('dropSiteZip')}
-      />
-      <div css={{ display: 'flex', '> *': { width: '50%' } }}>
-        <InputText
-          name="city"
-          label={t('request.facilityForm.dropSiteCity.label')}
-          value={dropSiteCity}
-          customOnChange={handleFieldChange('dropSiteCity')}
-        />
-        <InputDropdown
-          name="state"
-          label={t('request.facilityForm.dropSiteState.label')}
-          value={dropSiteState}
-          options={states}
-          customOnChange={handleFieldChange('dropSiteState')}
-        />
-      </div>
-      <InputText
-        name="address"
-        label={t('request.facilityForm.dropSiteAddress.label')}
-        value={dropSiteAddress}
-        customOnChange={handleFieldChange('dropSiteAddress')}
-      />
-      <InputText
-        name="url"
-        label={t('request.facilityForm.dropSiteUrl.label')}
-        isRequired={false}
-        value={dropSiteUrl}
-        customOnChange={handleFieldChange('dropSiteUrl')}
-      />
+      {CreateFormFields(formFieldsData)}
       <Note>
         {t('request.facilityForm.emailAt') + ' '}
         <Anchor href={`mailto:${Emails.HELP}`}>{Emails.HELP}</Anchor>

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -12,10 +12,8 @@ import Form from 'components/Form';
 import Anchor from 'components/Anchor';
 import Note from 'components/Note';
 import FacilityConfirmation from 'components/FacilityConfirmation';
-
-import CreateFormFields, {
-  formFieldTypes,
-} from 'components/Form/CreateFormFields';
+import CreateForm from 'components/Form/CreateForm';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 function FacilityForm({ backend, history }) {
   const { t } = useTranslation();
@@ -90,71 +88,70 @@ function FacilityForm({ backend, history }) {
     );
   }
 
-  const formFieldsData = [
-    {
-      customOnChange: handleFieldChange('dropSiteFacilityName'),
-      label: t('request.facilityForm.dropSiteFacilityName.label'),
-      name: 'name',
-      type: formFieldTypes.INPUT_TEXT,
-      value: dropSiteFacilityName,
-    },
-    {
-      customOnChange: handleFieldChange('dropSiteZip'),
-      label: t('request.facilityForm.dropSiteZip.label'),
-      name: 'zip',
-      type: formFieldTypes.INPUT_TEXT,
-      value: dropSiteZip,
-    },
-    {
-      customOnChange: handleFieldChange('dropSiteCity'),
-      isHalfWidth: true,
-      label: t('request.facilityForm.dropSiteCity.label'),
-      name: 'city',
-      type: formFieldTypes.INPUT_TEXT,
-      value: dropSiteCity,
-    },
-    {
-      customOnChange: handleFieldChange('dropSiteState'),
-      isHalfWidth: true,
-      label: t('request.facilityForm.dropSiteState.label'),
-      options: states,
-      name: 'state',
-      type: formFieldTypes.INPUT_DROPDOWN,
-      value: dropSiteState,
-    },
-    {
-      customOnChange: handleFieldChange('dropSiteAddress'),
-      label: t('request.facilityForm.dropSiteAddress.label'),
-      name: 'address',
-      type: formFieldTypes.INPUT_TEXT,
-      value: dropSiteAddress,
-    },
-    {
-      customOnChange: handleFieldChange('dropSiteUrl'),
-      isRequired: false,
-      label: t('request.facilityForm.dropSiteUrl.label'),
-      name: 'url',
-      type: formFieldTypes.INPUT_TEXT,
-      value: dropSiteUrl,
-    },
-  ];
+  const formData = {
+    buttonLabel: t('request.facilityForm.submit'),
+    defaultValues: fields,
+    description: t('request.facilityForm.description'),
+    disabled: !Object.keys(requiredFields).every((key) => !!fields[key]),
+    onSubmit: handleSubmit,
+    title: t('request.facilityForm.title'),
+    formFields: [
+      {
+        customOnChange: handleFieldChange('dropSiteFacilityName'),
+        label: t('request.facilityForm.dropSiteFacilityName.label'),
+        name: 'name',
+        type: formFieldTypes.INPUT_TEXT,
+        value: dropSiteFacilityName,
+      },
+      {
+        customOnChange: handleFieldChange('dropSiteZip'),
+        label: t('request.facilityForm.dropSiteZip.label'),
+        name: 'zip',
+        type: formFieldTypes.INPUT_TEXT,
+        value: dropSiteZip,
+      },
+      {
+        customOnChange: handleFieldChange('dropSiteCity'),
+        isHalfWidth: true,
+        label: t('request.facilityForm.dropSiteCity.label'),
+        name: 'city',
+        type: formFieldTypes.INPUT_TEXT,
+        value: dropSiteCity,
+      },
+      {
+        customOnChange: handleFieldChange('dropSiteState'),
+        isHalfWidth: true,
+        label: t('request.facilityForm.dropSiteState.label'),
+        options: states,
+        name: 'state',
+        type: formFieldTypes.INPUT_DROPDOWN,
+        value: dropSiteState,
+      },
+      {
+        customOnChange: handleFieldChange('dropSiteAddress'),
+        label: t('request.facilityForm.dropSiteAddress.label'),
+        name: 'address',
+        type: formFieldTypes.INPUT_TEXT,
+        value: dropSiteAddress,
+      },
+      {
+        customOnChange: handleFieldChange('dropSiteUrl'),
+        isRequired: false,
+        label: t('request.facilityForm.dropSiteUrl.label'),
+        name: 'url',
+        type: formFieldTypes.INPUT_TEXT,
+        value: dropSiteUrl,
+      },
+    ],
+    otherContent: [
+      <Note key="note">
+        If you’re working from a temporary facility, email us at{' '}
+        <Anchor href="mailto:help@help.supply">help@help.supply</Anchor>
+      </Note>,
+    ],
+  };
 
-  return (
-    <Form
-      defaultValues={fields}
-      buttonLabel={t('request.facilityForm.submit')}
-      onSubmit={handleSubmit}
-      title={t('request.facilityForm.title')}
-      disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
-      description={t('request.facilityForm.description')}
-    >
-      {CreateFormFields(formFieldsData)}
-      <Note>
-        {t('request.facilityForm.emailAt') + ' '}
-        <Anchor href={`mailto:${Emails.HELP}`}>{Emails.HELP}</Anchor>
-      </Note>
-    </Form>
-  );
+  return CreateForm(formData);
 }
 
 export default FacilityForm;

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -139,7 +139,6 @@ function FacilityForm({ backend, history }) {
 
   return (
     <FormBuilder
-      buttonLabel={t('request.facilityForm.submit')}
       defaultValues={fields}
       description={t('request.facilityForm.description')}
       disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
@@ -148,8 +147,8 @@ function FacilityForm({ backend, history }) {
       fields={formData}
     >
       <Note key="note">
-        If you’re working from a temporary facility, email us at{' '}
-        <Anchor href="mailto:help@help.supply">help@help.supply</Anchor>
+        {t('request.facilityForm.emailAt') + ' '}
+        <Anchor href={`mailto:${Emails.HELP}`}>{Emails.HELP}</Anchor>
       </Note>
     </FormBuilder>
   );

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -12,7 +12,7 @@ import Form from 'components/Form';
 import Anchor from 'components/Anchor';
 import Note from 'components/Note';
 import FacilityConfirmation from 'components/FacilityConfirmation';
-import CreateForm from 'components/Form/CreateForm';
+import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 function FacilityForm({ backend, history }) {
@@ -88,70 +88,71 @@ function FacilityForm({ backend, history }) {
     );
   }
 
-  const formData = {
-    buttonLabel: t('request.facilityForm.submit'),
-    defaultValues: fields,
-    description: t('request.facilityForm.description'),
-    disabled: !Object.keys(requiredFields).every((key) => !!fields[key]),
-    onSubmit: handleSubmit,
-    title: t('request.facilityForm.title'),
-    formFields: [
-      {
-        customOnChange: handleFieldChange('dropSiteFacilityName'),
-        label: t('request.facilityForm.dropSiteFacilityName.label'),
-        name: 'name',
-        type: formFieldTypes.INPUT_TEXT,
-        value: dropSiteFacilityName,
-      },
-      {
-        customOnChange: handleFieldChange('dropSiteZip'),
-        label: t('request.facilityForm.dropSiteZip.label'),
-        name: 'zip',
-        type: formFieldTypes.INPUT_TEXT,
-        value: dropSiteZip,
-      },
-      {
-        customOnChange: handleFieldChange('dropSiteCity'),
-        isHalfWidth: true,
-        label: t('request.facilityForm.dropSiteCity.label'),
-        name: 'city',
-        type: formFieldTypes.INPUT_TEXT,
-        value: dropSiteCity,
-      },
-      {
-        customOnChange: handleFieldChange('dropSiteState'),
-        isHalfWidth: true,
-        label: t('request.facilityForm.dropSiteState.label'),
-        options: states,
-        name: 'state',
-        type: formFieldTypes.INPUT_DROPDOWN,
-        value: dropSiteState,
-      },
-      {
-        customOnChange: handleFieldChange('dropSiteAddress'),
-        label: t('request.facilityForm.dropSiteAddress.label'),
-        name: 'address',
-        type: formFieldTypes.INPUT_TEXT,
-        value: dropSiteAddress,
-      },
-      {
-        customOnChange: handleFieldChange('dropSiteUrl'),
-        isRequired: false,
-        label: t('request.facilityForm.dropSiteUrl.label'),
-        name: 'url',
-        type: formFieldTypes.INPUT_TEXT,
-        value: dropSiteUrl,
-      },
-    ],
-    otherContent: [
+  const formData = [
+    {
+      customOnChange: handleFieldChange('dropSiteFacilityName'),
+      label: t('request.facilityForm.dropSiteFacilityName.label'),
+      name: 'name',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteFacilityName,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteZip'),
+      label: t('request.facilityForm.dropSiteZip.label'),
+      name: 'zip',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteZip,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteCity'),
+      isHalfWidth: true,
+      label: t('request.facilityForm.dropSiteCity.label'),
+      name: 'city',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteCity,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteState'),
+      isHalfWidth: true,
+      label: t('request.facilityForm.dropSiteState.label'),
+      options: states,
+      name: 'state',
+      type: formFieldTypes.INPUT_DROPDOWN,
+      value: dropSiteState,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteAddress'),
+      label: t('request.facilityForm.dropSiteAddress.label'),
+      name: 'address',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteAddress,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteUrl'),
+      isRequired: false,
+      label: t('request.facilityForm.dropSiteUrl.label'),
+      name: 'url',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteUrl,
+    },
+  ];
+
+  return (
+    <FormBuilder
+      buttonLabel={t('request.facilityForm.submit')}
+      defaultValues={fields}
+      description={t('request.facilityForm.description')}
+      disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
+      onSubmit={handleSubmit}
+      title={t('request.facilityForm.title')}
+      fields={formData}
+    >
       <Note key="note">
         If you’re working from a temporary facility, email us at{' '}
         <Anchor href="mailto:help@help.supply">help@help.supply</Anchor>
-      </Note>,
-    ],
-  };
-
-  return CreateForm(formData);
+      </Note>
+    </FormBuilder>
+  );
 }
 
 export default FacilityForm;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,7 @@
 {
   "translations": {
-    "generic.form.submitLabel": "Next",
+    "generic.form.submitLabel": "Submit",
+    "generic.form.submitLabelNext": "Next",
     "home.intro.learnMore": "Learn more",
     "home.intro.paragraph1": "Our platform gives a real-time view of the immediate needs of healthcare workers. We provide this information to the organizations of paid workers and volunteers that are ready and able to help.",
     "home.intro.paragraph2": "Want to know more about who we’re working with, or have supplies or services you want to donate?",
@@ -31,7 +32,6 @@
     "request.facilityForm.dropSiteUrl.label": "Website URL (optional)",
     "request.facilityForm.title": "Add a new facility",
     "request.facilityForm.description": "Enter some information about your facility.",
-    "request.facilityForm.submit": "Submit",
     "request.facilityForm.emailAt": "If you’re working from a temporary facility, email us at",
     "request.facilitySearch.addNew": "Add a new facility",
     "request.facilitySearch.description": "I'm a healthcare professional working at:",


### PR DESCRIPTION
Closes #106 

The new Need Services flow is going to require a handful of forms that will include a series of unique imports with some level of dynamic changes (if you change a service type the form fields will change). In an attempt to save some work laying out a bunch of form fields we're adding a utility that accepts an array of objects, each of which can be used to define an input.

This is likely to change over time, initially when we merge Izzy's Smart Forms PR and more often as we expand the functionality of each input type.

Note: I'll add this to all the forms once Izzy's PR is merged and the current form work stabilizes a bit.

I'll add some notes throughout.