### PR TITLE
chore(media-queries): setup facepaint and media queries utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "autosuggest-highlight": "^3.1.1",
     "axios": "^0.19.2",
     "bootstrap": "^4.4.1",
+    "facepaint": "^1.2.1",
     "firebase": "^7.11.0",
     "firebaseui": "^4.5.0",
     "mocha": "^7.1.1",

--- a/src/constants/breakpoints.js
+++ b/src/constants/breakpoints.js
@@ -1,0 +1,11 @@
+export const Breakpoints = {
+  MEDIUM: 480,
+  LARGE: 1024,
+  LARGER: 1920,
+};
+
+export const BreakpointsAll = [
+  Breakpoints.MEDIUM,
+  Breakpoints.LARGE,
+  Breakpoints.LARGER,
+];

--- a/src/lib/utils/media-queries.js
+++ b/src/lib/utils/media-queries.js
@@ -1,0 +1,9 @@
+import { css as emotionCSS } from '@emotion/core';
+import facepaint from 'facepaint';
+
+import { BreakpointsAll } from 'constants/breakpoints';
+
+const mediaQueries = BreakpointsAll.map((bp) => `@media(min-width: ${bp}px)`);
+const mq = facepaint(mediaQueries);
+
+export const css = (...rules) => emotionCSS(mq(rules));

--- a/src/pages/entry.js
+++ b/src/pages/entry.js
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { css } from '@emotion/core';
 import { Fragment } from 'react';
+import { css } from 'lib/utils/media-queries';
 import { Color, Space } from 'lib/theme';
 import Anchor from 'components/Anchor';
 import Box from 'components/Box';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4986,6 +4986,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+facepaint@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/facepaint/-/facepaint-1.2.1.tgz#89929e601b15227278c53c516f764fc462b09c33"
+  integrity sha512-oNvBekbhsm/0PNSOWca5raHNAi6dG960Bx6LJgxDPNF59WpuspgQ17bN5MKwOr7JcFdQYc7StW3VZ28DBZLavQ==
+
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"


### PR DESCRIPTION
Issue #112 

- Installed [facepaint](https://emotion.sh/docs/media-queries#facepaint) to utilize responsive styles
- Created constants for breakpoints
- Set up utility for media-queries

**Testing:**
- Replace `css` import from `@emotion/core` with the new utility
- Use array in place of singular value `['pink', 'blue', 'green', 'yellow']`

Note: I copied over some values for breakpoints from another project. Happy to change these up if others have opinions. Just needed to get some media-queries in place to start working on the desktop design for start page.