### PR TITLE
Improve the ui of the dropdown

### DIFF
--- a/src/components/InputDropdown/InputDropdown.styles.js
+++ b/src/components/InputDropdown/InputDropdown.styles.js
@@ -1,24 +1,41 @@
 import { css } from '@emotion/core';
 import { Borders, Color, selectReset, Radius, Space, Height } from 'lib/theme';
 
+const activeLabel = {
+  fontSize: 12,
+  paddingTop: Space.S10,
+};
+
 const styles = {
+  activeLabel: css(activeLabel),
   chevron: css({
     position: 'absolute',
+    pointerEvents: 'none',
     right: Space.S25,
     top: Space.S25,
+    transition: 'transform 0.2s ease-in-out',
+  }),
+  label: css({
+    color: Color.GRAY_50,
+    fontSize: 16,
+    position: 'absolute',
+    height: '100%',
+    paddingTop: Space.S20,
+    left: Space.S20,
+    pointerEvents: 'none',
+    transition: '0.2s all ease-in-out',
   }),
   error: css({
     color: Color.CORAL,
     position: 'absolute',
     top: Height.INPUT,
   }),
-  placeholder: css({
+  optionLabel: css({
     color: Color.GRAY_50,
     paddingLeft: Space.S25,
     paddingTop: Space.S20,
     position: 'absolute',
   }),
-
   root: css({
     border: Borders.TRANSPARENT,
     borderRadius: Radius.ROUNDED,
@@ -27,21 +44,25 @@ const styles = {
     height: Height.INPUT,
     position: 'relative',
 
-    '&:focus-within svg': {
-      transform: 'rotate(180deg)',
+    '&:focus-within': {
+      borderColor: Color.CORAL_30,
+
+      '& svg': {
+        transform: 'rotate(180deg)',
+      },
+
+      '& div': activeLabel,
     },
   }),
-
   select: css({
     ...selectReset,
     border: Borders.GRAY,
     borderRadius: Radius.ROUNDED,
     height: '100%',
-    padding: `0 ${Space.S20}px`,
+    padding: `${Space.S10}px ${Space.S20}px 0`,
   }),
-
   selectDefaultState: css({
-    color: Color.GRAY_50,
+    color: 'transparent',
   }),
 };
 

--- a/src/components/InputDropdown/index.js
+++ b/src/components/InputDropdown/index.js
@@ -17,7 +17,7 @@ function InputDropdown({
   inputProps,
   options = [],
   name,
-  placeholder,
+  label,
   isRequired = true,
 }) {
   const [value, setValue] = useState(DEFAULT);
@@ -34,6 +34,11 @@ function InputDropdown({
   );
   return (
     <div css={styles.root}>
+      {label && (
+        <div css={[styles.label, value !== DEFAULT && styles.activeLabel]}>
+          {label}
+        </div>
+      )}
       <select
         css={[styles.select, value === DEFAULT && styles.selectDefaultState]}
         onChange={handleChange}
@@ -42,8 +47,8 @@ function InputDropdown({
         ref={register && register({ ...(isRequired && { required }) })}
         {...inputProps}
       >
-        <option css={styles.placeholder} disabled value={DEFAULT}>
-          {placeholder}
+        <option css={styles.optionLabel} disabled value={DEFAULT}>
+          {label}
         </option>
 
         {options.map((o) => (

--- a/src/components/StyleGuide/index.js
+++ b/src/components/StyleGuide/index.js
@@ -101,7 +101,7 @@ function StyleGuide({ backend }) {
           </div>
           <div>
             <InputDropdown
-              placeholder="Select supply type"
+              label="Select supply type"
               options={[
                 { label: 'Foo', value: 'foo' },
                 { label: 'Bar', value: 'bar' },

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -107,7 +107,7 @@ function FacilityForm({ backend, history }) {
         />
         <InputDropdown
           name="state"
-          placeholder={t('request.facilityForm.dropSiteState.label')}
+          label={t('request.facilityForm.dropSiteState.label')}
           value={dropSiteState}
           options={states}
           customOnChange={handleFieldChange('dropSiteState')}

--- a/src/containers/SupplyForm.js
+++ b/src/containers/SupplyForm.js
@@ -45,13 +45,13 @@ function SupplyForm({ onSubmit }) {
     >
       <InputDropdown
         name="type"
-        placeholder={t('request.supplyForm.type.label')}
+        label={t('request.supplyForm.type.label')}
         value={type}
         customOnChange={handleFieldChange('type')}
       />
       <InputDropdown
         name="kind"
-        placeholder={t('request.supplyForm.kind.label')}
+        label={t('request.supplyForm.kind.label')}
         value={kind}
         customOnChange={handleFieldChange('kind')}
       />


### PR DESCRIPTION
* Clicking right on the arrow icon doesn’t open the dropdown (need pointer-events: none).
* The label doesn’t transition up into the corner like on see on the other inputs.
* Added focus border as seen on other inputs.

![Large GIF (450x916)](https://user-images.githubusercontent.com/1128500/77843989-1bc1ca80-7157-11ea-85c0-7900df991c3e.gif)
