### PR TITLE
chore(forms): use FormBuilder where applicable

### DIFF
--- a/src/components/Autosuggest/Autosuggest.styles.js
+++ b/src/components/Autosuggest/Autosuggest.styles.js
@@ -35,7 +35,9 @@ const styles = {
     borderRadius: Radius.ROUNDED,
     display: 'flex',
     flexDirection: 'column',
+    margin: `0 0 ${Space.S30}px 0`,
     position: 'relative',
+    width: '100%',
 
     '.react-autosuggest__container': {
       height: Height.INPUT,

--- a/src/components/Form/CreateFormFields.js
+++ b/src/components/Form/CreateFormFields.js
@@ -1,12 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import HeaderInfo from 'components/Form/HeaderInfo';
+import InputCheckbox from 'components/Checkbox';
 import InputText from 'components/InputText';
 import InputDropdown from 'components/InputDropdown';
+import TextArea from 'components/TextArea';
 
 export const formFieldTypes = {
+  HEADER_INFO: 'HEADER_INFO',
+  INPUT_CHECKBOX: 'INPUT_CHECKBOX',
   INPUT_DROPDOWN: 'INPUT_DROPDOWN',
   INPUT_TEXT: 'INPUT_TEXT',
+  NODE: 'NODE',
+  TEXT_AREA: 'TEXT_AREA',
 };
 
 export const formFieldPropTypes = {
@@ -14,23 +21,30 @@ export const formFieldPropTypes = {
   isHalfWidth: PropTypes.bool,
   isRequired: PropTypes.bool,
   label: PropTypes.string,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   options: PropTypes.array,
   placeholder: PropTypes.string,
   type: PropTypes.oneOf(Object.values(formFieldTypes)).isRequired,
+  validation: PropTypes.object,
   value: PropTypes.string,
 };
 
 const inputMap = {
+  [formFieldTypes.HEADER_INFO]: HeaderInfo,
+  [formFieldTypes.INPUT_CHECKBOX]: InputCheckbox,
   [formFieldTypes.INPUT_DROPDOWN]: InputDropdown,
   [formFieldTypes.INPUT_TEXT]: InputText,
+  [formFieldTypes.TEXT_AREA]: TextArea,
 };
 
 function CreateFormFields(fields) {
   const formFields = fields.map(({ type, ...rest }) => {
-    const InputEl = inputMap[type];
+    if (type === formFieldTypes.NODE) {
+      return rest.node;
+    }
 
-    return <InputEl key={rest.label} {...rest} />;
+    const InputEl = inputMap[type];
+    return <InputEl key={rest.label || rest.title} {...rest} />;
   });
 
   return formFields;

--- a/src/components/Form/HeaderInfo.js
+++ b/src/components/Form/HeaderInfo.js
@@ -9,13 +9,13 @@ import styles from './Form.styles.js';
 function InfoHeader({
   as = 'h3',
   description,
+  textType = TEXT_TYPE.HEADER_3,
   title,
-  type = TEXT_TYPE.HEADER_3,
 }) {
   return (
     <div>
       {title && (
-        <Text as={as} type={type} css={styles.title}>
+        <Text as={as} type={textType} css={styles.title}>
           {title}
         </Text>
       )}

--- a/src/components/TextArea/TextArea.styles.js
+++ b/src/components/TextArea/TextArea.styles.js
@@ -45,6 +45,7 @@ const styles = {
     paddingTop: Space.S20,
     left: Space.S20,
     pointerEvents: 'none',
+    right: Space.S20,
     transition: '0.2s all ease-in-out',
   }),
   root: css({
@@ -53,7 +54,9 @@ const styles = {
     borderRadius: Radius.ROUNDED,
     flexDirection: 'column',
     height: 240,
+    margin: `0 0 ${Space.S30}px 0`,
     position: 'relative',
+    width: '100%',
   }),
 };
 

--- a/src/containers/DropSiteForm.js
+++ b/src/containers/DropSiteForm.js
@@ -1,12 +1,9 @@
 import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import InputCheckbox from 'components/Checkbox';
-import Form from 'components/Form';
-import HeaderInfo from 'components/Form/HeaderInfo';
-import InputText from 'components/InputText';
 import { TEXT_TYPE } from 'components/Text/constants';
-import TextArea from 'components/TextArea';
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 export const DropSiteForm = ({ dropSite, onSubmit }) => {
   const { t } = useTranslation();
@@ -29,70 +26,87 @@ export const DropSiteForm = ({ dropSite, onSubmit }) => {
     const { dropSiteId, ...state } = fields;
     onSubmit({ ...state, location_id: dropSiteId });
   }, [fields, onSubmit]);
+
   const {
     dropSiteAddress,
     dropSiteDescription,
     dropSiteName,
     dropSitePhone,
   } = fields;
+
+  const fieldData = [
+    {
+      customOnChange: handleFieldChange('dropSiteAddress'),
+      label: t('request.dropSiteForm.dropSiteAddress.label'),
+      name: 'address',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteAddress,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteDescription'),
+      label: t('request.dropSiteForm.dropSiteDescription.label'),
+      name: 'details',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteDescription,
+    },
+    {
+      as: 'h4',
+      description: t('request.dropSiteForm.requirements.description'),
+      title: t('request.dropSiteForm.requirements.title'),
+      textType: TEXT_TYPE.HEADER_4,
+      type: formFieldTypes.HEADER_INFO,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteRequirements'),
+      label: t('request.dropSiteForm.dropSiteRequirements.label'),
+      name: 'requirement',
+      type: formFieldTypes.TEXT_AREA,
+    },
+    {
+      as: 'h4',
+      description: t('request.dropSiteForm.moreInfo.description'),
+      title: t('request.dropSiteForm.moreInfo.title'),
+      textType: TEXT_TYPE.HEADER_4,
+      type: formFieldTypes.HEADER_INFO,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteName'),
+      isRequired: false,
+      label: t('request.dropSiteForm.dropSiteName.label'),
+      name: 'name',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSiteName,
+    },
+    {
+      customOnChange: handleFieldChange('dropSitePhone'),
+      isRequired: false,
+      label: t('request.dropSiteForm.dropSitePhone.label'),
+      name: 'phone',
+      type: formFieldTypes.INPUT_TEXT,
+      value: dropSitePhone,
+    },
+    {
+      customOnChange: handleFieldChange('dropSiteNotes'),
+      label: t('request.dropSiteForm.dropSiteNotes.label'),
+      name: 'notes',
+      type: formFieldTypes.TEXT_AREA,
+    },
+    {
+      customOnChange: handleFieldChange('requestWillingToPay'),
+      label: t('request.dropSiteForm.requestWillingToPay.label'),
+      name: 'willingnessToPay',
+      type: formFieldTypes.INPUT_CHECKBOX,
+    },
+  ];
+
   return (
-    <Form
+    <FormBuilder
       defaultValues={fields}
       onSubmit={handleSubmit}
       title={t('request.dropSiteForm.title')}
       description={t('request.dropSiteForm.description')}
-    >
-      <InputText
-        name="address"
-        label={t('request.dropSiteForm.dropSiteAddress.label')}
-        value={dropSiteAddress}
-        customOnChange={handleFieldChange('dropSiteAddress')}
-      />
-      <InputText
-        name="details"
-        label={t('request.dropSiteForm.dropSiteDescription.label')}
-        value={dropSiteDescription}
-        customOnChange={handleFieldChange('dropSiteDescription')}
-      />
-      <HeaderInfo
-        as="h4"
-        type={TEXT_TYPE.HEADER_4}
-        title={t('request.dropSiteForm.requirements.title')}
-        description={t('request.dropSiteForm.requirements.description')}
-      />
-      <TextArea
-        customOnChange={handleFieldChange('dropSiteRequirements')}
-        label={t('request.dropSiteForm.dropSiteRequirements.label')}
-      />
-      <HeaderInfo
-        as="h4"
-        type={TEXT_TYPE.HEADER_4}
-        title={t('request.dropSiteForm.moreInfo.title')}
-        description={t('request.dropSiteForm.moreInfo.description')}
-      />
-      <InputText
-        name="name"
-        label={t('request.dropSiteForm.dropSiteName.label')}
-        value={dropSiteName}
-        isRequired={false}
-        customOnChange={handleFieldChange('dropSiteName')}
-      />
-      <InputText
-        name="phone"
-        label={t('request.dropSiteForm.dropSitePhone.label')}
-        value={dropSitePhone}
-        isRequired={false}
-        customOnChange={handleFieldChange('dropSitePhone')}
-      />
-      <TextArea
-        label={t('request.dropSiteForm.dropSiteNotes.label')}
-        customOnChange={handleFieldChange('dropSiteNotes')}
-      />
-      <InputCheckbox
-        customOnChange={handleFieldChange('requestWillingToPay')}
-        label={t('request.dropSiteForm.requestWillingToPay.label')}
-      />
-    </Form>
+      fields={fieldData}
+    />
   );
 };
 

--- a/src/containers/EmailForm.js
+++ b/src/containers/EmailForm.js
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { jsx } from '@emotion/core';
 
 import { Routes } from 'constants/Routes';
+import { isValidEmail } from 'lib/utils/validations';
 
-import Form from 'components/Form';
-import InputText from 'components/InputText';
 import Note from 'components/Note';
 import Anchor from 'components/Anchor';
 import HeaderInfo from 'components/Form/HeaderInfo';
-import { isValidEmail } from 'lib/utils/validations';
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 const validate = (val) => {
   if (!isValidEmail(val)) {
@@ -48,27 +48,32 @@ function EmailForm({ backend, match }) {
     );
   }
 
+  const fieldData = [
+    {
+      customOnChange: setEmail,
+      label: t('request.workEmailForm.workEmail.label'),
+      name: 'email',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate },
+    },
+  ];
+
   return (
-    <Form
+    <FormBuilder
       defaultValues={{ email: '' }}
       onSubmit={handleSubmit}
       title={t('request.workEmailForm.title')}
       description={t('request.workEmailForm.description')}
       disabled={!isValidEmail(email)}
+      fields={fieldData}
     >
-      <InputText
-        name="email"
-        label={t('request.workEmailForm.workEmail.label')}
-        validation={{ validate }}
-        customOnChange={setEmail}
-      />
       <Note>
         {t('request.workEmailForm.workEmail.disclaimer') + ' '}
         <Anchor href={Routes.HOME}>
           {t('request.workEmailForm.learnMore')}
         </Anchor>
       </Note>
-    </Form>
+    </FormBuilder>
   );
 }
 

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -88,7 +88,7 @@ function FacilityForm({ backend, history }) {
     );
   }
 
-  const formData = [
+  const fieldData = [
     {
       customOnChange: handleFieldChange('dropSiteFacilityName'),
       label: t('request.facilityForm.dropSiteFacilityName.label'),
@@ -144,7 +144,7 @@ function FacilityForm({ backend, history }) {
       disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
       onSubmit={handleSubmit}
       title={t('request.facilityForm.title')}
-      fields={formData}
+      fields={fieldData}
     >
       <Note key="note">
         {t('request.facilityForm.emailAt') + ' '}

--- a/src/containers/SupplyForm.js
+++ b/src/containers/SupplyForm.js
@@ -1,15 +1,15 @@
 /** @jsx jsx */
 import { useState, useCallback } from 'react';
 import { jsx } from '@emotion/core';
-import Form from 'components/Form';
-import InputCheckbox from 'components/Checkbox';
-import InputDropdown from 'components/InputDropdown';
-import InputText from 'components/InputText';
+import { useTranslation } from 'react-i18next';
+
+import { Space } from 'lib/theme';
+
 import Note from 'components/Note';
 import Text from 'components/Text';
 import { TEXT_TYPE } from 'components/Text/constants';
-import TextArea from 'components/TextArea';
-import { useTranslation } from 'react-i18next';
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 function SupplyForm({ onSubmit }) {
   const { t } = useTranslation();
@@ -34,55 +34,70 @@ function SupplyForm({ onSubmit }) {
 
   const { detailedRequirements, type, kind, quantity } = fields;
 
+  const fieldData = [
+    {
+      customOnChange: handleFieldChange('type'),
+      label: t('request.supplyForm.type.label'),
+      name: 'type',
+      type: formFieldTypes.INPUT_DROPDOWN,
+      value: type,
+    },
+    {
+      customOnChange: handleFieldChange('kind'),
+      label: t('request.supplyForm.kind.label'),
+      name: 'kind',
+      type: formFieldTypes.INPUT_DROPDOWN,
+      value: kind,
+    },
+    {
+      customOnChange: handleFieldChange('quantity'),
+      label: t('request.supplyForm.quantity.label'),
+      name: 'quantity',
+      type: formFieldTypes.INPUT_TEXT,
+      value: quantity,
+    },
+    {
+      type: formFieldTypes.NODE,
+      node: [
+        <Text as="p" key="text" type={TEXT_TYPE.BODY_2}>
+          {t('request.supplyForm.detailedRequirements.note')}
+        </Text>,
+      ],
+    },
+    {
+      customOnChange: handleFieldChange('detailedRequirements'),
+      label: t('request.supplyForm.detailedRequirements.label'),
+      name: 'detailedRequirements',
+      type: formFieldTypes.TEXT_AREA,
+      value: detailedRequirements,
+    },
+    {
+      customOnChange: handleFieldChange('requestWillingToPay'),
+      label: t('request.supplyForm.facilityWillPayLargeVolumes.label'),
+      name: 'facilityWillPayLargeVolumes',
+      type: formFieldTypes.INPUT_CHECKBOX,
+      value: '1',
+    },
+    {
+      type: formFieldTypes.NODE,
+      node: [
+        <Note key="note-2" css={{ marginTop: Space.S20, width: '100%' }}>
+          {t('request.supplyForm.disclaimer')}
+        </Note>,
+      ],
+    },
+  ];
+
   return (
-    <Form
+    <FormBuilder
       defaultValues={fields}
       buttonLabel="Submit"
       onSubmit={handleSubmit}
       description={t('request.supplyForm.description')}
       title={t('request.supplyForm.title')}
       disabled={!Object.keys(fields).every((key) => !!fields[key])}
-    >
-      <InputDropdown
-        name="type"
-        label={t('request.supplyForm.type.label')}
-        value={type}
-        customOnChange={handleFieldChange('type')}
-      />
-      <InputDropdown
-        name="kind"
-        label={t('request.supplyForm.kind.label')}
-        value={kind}
-        customOnChange={handleFieldChange('kind')}
-      />
-      <InputText
-        name="quantity"
-        label={t('request.supplyForm.quantity.label')}
-        value={quantity}
-        customOnChange={handleFieldChange('quantity')}
-      />
-      <Note>{t('request.supplyForm.disclaimer')}</Note>
-
-      <Text as="p" type={TEXT_TYPE.BODY_2}>
-        {t('request.supplyForm.detailedRequirements.note')}
-      </Text>
-
-      <TextArea
-        customOnChange={handleFieldChange('detailedRequirements')}
-        label={t('request.supplyForm.detailedRequirements.label')}
-        name="detailedRequirements"
-        value={detailedRequirements}
-      />
-
-      <InputCheckbox
-        customOnChange={handleFieldChange('requestWillingToPay')}
-        label={t('request.supplyForm.facilityWillPayLargeVolumes.label')}
-        name="facilityWillPayLargeVolumes"
-        value="1"
-      />
-
-      <Note>{t('request.supplyForm.disclaimer')}</Note>
-    </Form>
+      fields={fieldData}
+    />
   );
 }
 


### PR DESCRIPTION
- Moved container forms to `<FormBuilder />`
- Added support for `TextArea` & `Checkbox`
- Added `NODE` type to allow for injection of content nodes (or anything else that is needed).