### PR TITLE
fix routing and placholder dropsite creation

### DIFF
--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -13,7 +13,7 @@ export const Routes = {
   REQUEST_SERVICES: '/request-services',
   REQUEST_SUPPLIES: '/request',
   SIGNUP_DROPSITE: `/signup/:id`,
-  SIGNUP_FINISH_DROPSITE: `/signupFinish/:dropsite?`,
+  SIGNUP_FINISH_DROPSITE: `/signupFinish/:id`,
   STYLE_GUIDE: '/style-guide',
   SUPPLY_NEW_ADMIN: `/new/admin/supply/:id`,
 };

--- a/src/containers/FindFacility.js
+++ b/src/containers/FindFacility.js
@@ -95,26 +95,36 @@ function FindFacility({ backend, history }) {
     if (!selectedResult) {
       return;
     }
-
-    if (backend.authLoaded && backend.isLoggedIn()) {
-      backend.dropSiteExists(selectedResult).then((exists) => {
-        if (exists) {
+    const facility = hospital_index.index.id_index[selectedResult];
+    backend
+      .dropSiteExists(selectedResult)
+      .then((exists) => {
+        if (!exists) {
+          // create dropsite with corresponding facilty id and info
+          backend.addDropSite({
+            location_id: selectedResult,
+            dropSiteFacilityName: facility.name,
+            dropSiteCity: facility.city,
+            dropSiteState: facility.state,
+            dropSiteZip: facility.zip,
+          });
+        }
+      })
+      .then(() => {
+        if (backend.authLoaded && backend.isLoggedIn()) {
           history.push(
-            routeWithParams(Routes.DROPSITE_ADMIN, { id: selectedResult }),
+            routeWithParams(Routes.DROPSITE_ADMIN, {
+              id: selectedResult,
+            }),
           );
         } else {
           history.push(
-            routeWithParams(Routes.DROPSITE_NEW_ADMIN, {
+            routeWithParams(Routes.SIGNUP_DROPSITE, {
               id: selectedResult,
             }),
           );
         }
       });
-    } else {
-      history.push(
-        routeWithParams(Routes.SIGNUP_DROPSITE, { id: selectedResult }),
-      );
-    }
   }, [backend, history, selectedResult]);
 
   return (

--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -74,10 +74,11 @@ class FirebaseBackend extends BackendInterface {
       dropSite.location_id &&
       dropSite.dropSiteAddress
     ) {
+      const { currentUser } = this.firebase.auth();
       let newSiteObj = {
         ...dropSite,
-        domain: this.firebase.auth().currentUser.email.split('@')[1],
-        user: this.firebase.auth().currentUser.uid,
+        domain: currentUser.email.split('@')[1],
+        user: currentUser.uid,
       };
       return this.firestore
         .collection('dropSite')
@@ -99,14 +100,15 @@ class FirebaseBackend extends BackendInterface {
   // is not signed with any credentials and assumed to be invalid until
   // it is edited later in the flow.
   addNewDropSite({
-    dropSiteFacilityName,
-    dropSiteZip,
-    dropSiteAddress,
-    dropSiteCity,
-    dropSiteState,
-    dropSiteUrl,
+    dropSiteFacilityName = '',
+    dropSiteZip = '',
+    dropSiteAddress = '',
+    dropSiteCity = '',
+    dropSiteState = '',
+    dropSiteUrl = '',
   }) {
-    if (dropSiteFacilityName && dropSiteAddress && dropSiteZip) {
+    if (dropSiteFacilityName && dropSiteZip) {
+      const { currentUser } = this.firebase.auth();
       let newSiteObj = {
         dropSiteFacilityName,
         dropSiteZip,
@@ -114,6 +116,8 @@ class FirebaseBackend extends BackendInterface {
         dropSiteCity,
         dropSiteState,
         dropSiteUrl,
+        domain: currentUser?.email.split('@')[1] || '',
+        user: currentUser?.uid || '',
       };
       let db = this.firestore;
       return db

--- a/src/pages/dropsite_contact.js
+++ b/src/pages/dropsite_contact.js
@@ -3,10 +3,13 @@ import { useEffect, useState } from 'react';
 import { jsx } from '@emotion/core';
 import { withRouter } from 'react-router-dom';
 
+import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
+
 import Page from 'components/layouts/Page';
 import ContactForm from 'containers/ContactForm';
 
-function ContactDropSite({ backend, match }) {
+function ContactDropSite({ backend, history, match }) {
   const [dropSite, setDropSite] = useState();
   useEffect(() => {
     backend.getDropSites(match.params.id).then((data) => {
@@ -19,7 +22,17 @@ function ContactDropSite({ backend, match }) {
   }
 
   return (
-    <Page currentProgress={4} totalProgress={5}>
+    <Page
+      onBackButtonClick={() =>
+        history.push(
+          routeWithParams(Routes.DROPSITE_ADMIN, {
+            id: match.params.id,
+          }),
+        )
+      }
+      currentProgress={4}
+      totalProgress={5}
+    >
       <ContactForm backend={backend} dropSite={dropSite} />
     </Page>
   );


### PR DESCRIPTION
When a facility dropsite does not exist in our database but does exist in the hospital index we want to create a placeholder dropsite with the facility ID. If it does not exist in the hospital index it will generate a unique id.

From there we route accordingly if the user is logged in or not, and whether the dropsite has requests or not.

@newhouseb is currently working on permissions so this flow might need to be adjusted