### PR TITLE
chore(facility): add pages for facility confirmation and edit

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,8 @@ import AdminDropSite from 'pages/dropsite_admin';
 import ContactDropSite from 'pages/dropsite_contact';
 import ContactDropSiteConfirmation from 'pages/dropsite_contact_confirmation';
 import NewFacility from 'pages/facility_new';
+import FacilityConfirmation from 'pages/facility_confirmation';
+import FacilityEdit from 'pages/facility_edit';
 import NewDropSite from 'pages/dropsite_new';
 import EntryPortal from 'pages/entry';
 import Request from 'pages/request';
@@ -136,10 +138,15 @@ function App({ backend }) {
             <Route path={Routes.SIGNUP_DROPSITE}>
               <SignUp backend={backend} />
             </Route>
-            <Route path={Routes.NEW_FACILITY}>
+            <Route exact path={Routes.NEW_FACILITY}>
               <NewFacility backend={backend} />
             </Route>
-
+            <Route exact path={Routes.FACILITY_CONFIRMATION}>
+              <FacilityConfirmation backend={backend} />
+            </Route>
+            <Route exact path={Routes.FACILITY_EDIT}>
+              <FacilityEdit backend={backend} />
+            </Route>
             <Route path="*">
               <NoMatch />
             </Route>

--- a/src/components/Confirmation/FacilityConfirmation.js
+++ b/src/components/Confirmation/FacilityConfirmation.js
@@ -8,7 +8,14 @@ import Text from 'components/Text';
 import SubRow from './SubRow';
 import ConfirmationWrapper from './ConfirmationWrapper';
 
-function FacilityConfirmation({ onEdit, name, address }) {
+function FacilityConfirmation({
+  onEdit,
+  name,
+  streetAddress,
+  city,
+  state,
+  zip,
+}) {
   const { t } = useTranslation();
 
   return (
@@ -20,7 +27,11 @@ function FacilityConfirmation({ onEdit, name, address }) {
         details={
           <Fragment>
             <Text as="p">{name}</Text>
-            <Text as="p">{address}</Text>
+            <Text as="p">
+              {streetAddress}
+              <br />
+              {`${city}, ${state}  ${zip}`}
+            </Text>
           </Fragment>
         }
       />

--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -4,6 +4,8 @@ export const Routes = {
   DROPSITE_CONTACT_CONFIRMATION: `/dropsite/:id/contact/confirmation`,
   DROPSITE_DETAIL: `/dropsite/:id`,
   DROPSITE_NEW_ADMIN: `/dropsite/new/admin/:id`,
+  FACILITY_CONFIRMATION: '/facility/:id/confirmation',
+  FACILITY_EDIT: '/facility/:id/edit',
   FAQ: '/faq',
   HOME: '/',
   LOGIN: '/login',

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -2,7 +2,10 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { jsx } from '@emotion/core';
+import { useHistory } from 'react-router-dom';
 
+import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
 import { Emails } from 'constants/Emails';
 
 import states from 'data/states';
@@ -12,16 +15,41 @@ import Note from 'components/Note';
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
-function FacilityForm({ handleSubmit, history, dropSite }) {
+function FacilityForm({ backend, dropSite, dropSiteId }) {
   const { t } = useTranslation();
+  const history = useHistory();
+
+  const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState({
-    dropSiteFacilityName: dropSite.dropSiteFacilityName || '',
-    dropSiteZip: dropSite.dropSiteZip || '',
-    dropSiteAddress: dropSite.dropSiteAddress || '',
-    dropSiteCity: dropSite.dropSiteCity || '',
-    dropSiteState: dropSite.dropSiteState || '',
-    dropSiteUrl: dropSite.dropSiteUrl || '',
+    dropSiteFacilityName: dropSite?.dropSiteFacilityName || '',
+    dropSiteZip: dropSite?.dropSiteZip || '',
+    dropSiteAddress: dropSite?.dropSiteAddress || '',
+    dropSiteCity: dropSite?.dropSiteCity || '',
+    dropSiteState: dropSite?.dropSiteState || '',
+    dropSiteUrl: dropSite?.dropSiteUrl || '',
   });
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+
+    if (dropSiteId) {
+      return backend
+        .editDropSite({ location_id: dropSiteId, ...fields })
+        .then((data) => {
+          history.push(
+            routeWithParams(Routes.FACILITY_CONFIRMATION, { id: dropSiteId }),
+          );
+        });
+    }
+
+    backend.addNewDropSite(fields).then((data) => {
+      if (!data) {
+        return;
+      }
+
+      history.push(routeWithParams(Routes.FACILITY_CONFIRMATION, { id: data }));
+    });
+  };
 
   const handleFieldChange = useCallback(
     (field) => (value) => {
@@ -99,6 +127,7 @@ function FacilityForm({ handleSubmit, history, dropSite }) {
       onSubmit={() => handleSubmit(fields)}
       title={t('request.facilityForm.title')}
       fields={fieldData}
+      isLoading={isLoading}
     >
       <Note key="note">
         {t('request.facilityForm.emailAt') + ' '}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -3,7 +3,6 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 
 import englishLocale from './locales/en.json';
-console.log(englishLocale);
 
 i18n
   .use(LanguageDetector)

--- a/src/pages/facility_confirmation.js
+++ b/src/pages/facility_confirmation.js
@@ -1,0 +1,52 @@
+/** @jsx jsx */
+import { useEffect, useState } from 'react';
+import { jsx } from '@emotion/core';
+import { useHistory, useParams } from 'react-router-dom';
+
+import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
+
+import Page from 'components/layouts/Page';
+import PageLoader from 'components/Loader/PageLoader';
+import { FacilityConfirmation as FacilityConfirmationComponent } from 'components/Confirmation';
+
+function FacilityConfirmation({ backend }) {
+  const history = useHistory();
+  const params = useParams();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [dropSite, setDropSite] = useState();
+
+  useEffect(() => {
+    backend.getDropSites(params.id).then((data) => {
+      setDropSite(data);
+      setIsLoading(false);
+    });
+  }, [backend, params.id]);
+
+  const handleOnEdit = () => {
+    history.push(
+      routeWithParams(Routes.FACILITY_EDIT, {
+        id: dropSite.location_id,
+      }),
+    );
+  };
+
+  return (
+    <Page currentProgress={2} totalProgress={5}>
+      {isLoading && <PageLoader />}
+      {!isLoading && (
+        <FacilityConfirmationComponent
+          onEdit={handleOnEdit}
+          name={dropSite.dropSiteFacilityName}
+          streetAddress={dropSite.dropSiteAddress}
+          city={dropSite.dropSiteCity}
+          state={dropSite.dropSiteState}
+          zip={dropSite.dropSiteZip}
+        />
+      )}
+    </Page>
+  );
+}
+
+export default FacilityConfirmation;

--- a/src/pages/facility_edit.js
+++ b/src/pages/facility_edit.js
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+import { useEffect, useState } from 'react';
+import { jsx } from '@emotion/core';
+import { useParams } from 'react-router-dom';
+
+import Page from 'components/layouts/Page';
+import PageLoader from 'components/Loader/PageLoader';
+import FacilityForm from 'containers/FacilityForm';
+
+function FacilityEdit({ backend }) {
+  const params = useParams();
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [dropSite, setDropSite] = useState();
+
+  useEffect(() => {
+    backend.getDropSites(params.id).then((data) => {
+      setDropSite(data);
+      setIsLoading(false);
+    });
+  }, [backend, params.id]);
+
+  return (
+    <Page currentProgress={2} totalProgress={5}>
+      {isLoading && <PageLoader />}
+      {!isLoading && (
+        <FacilityForm
+          backend={backend}
+          dropSite={dropSite}
+          dropSiteId={params.id}
+        />
+      )}
+    </Page>
+  );
+}
+
+export default FacilityEdit;

--- a/src/pages/facility_new.js
+++ b/src/pages/facility_new.js
@@ -1,93 +1,15 @@
 /** @jsx jsx */
-import { useState, useEffect } from 'react';
 import { jsx } from '@emotion/core';
-import { withRouter } from 'react-router-dom';
 
-import { Routes } from 'constants/Routes';
-import { routeWithParams } from 'lib/utils/routes';
 import Page from 'components/layouts/Page';
 import FacilityForm from 'containers/FacilityForm';
-import Form from 'components/Form';
-import { FacilityConfirmation } from 'components/Confirmation';
 
-function NewFacility({ backend, history }) {
-  const [dropSite, setDropSite] = useState({});
-  const [sent, setSent] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [dropSiteId, setDropSiteId] = useState('');
-  useEffect(() => {
-    backend.getDropSites(dropSiteId).then((data) => {
-      setDropSite(data);
-    });
-  }, [backend, dropSiteId]);
-
-  useEffect(() => {
-    if (dropSiteId) {
-      backend.getDropSites(dropSiteId).then((data) => {
-        if (!data) {
-          return;
-        }
-        setLoading(false);
-        setDropSite(data);
-      });
-    }
-  }, [backend, dropSiteId, sent]);
-
-  const handleSubmit = (dropSite) => {
-    setLoading(true);
-    if (dropSiteId) {
-      return backend
-        .editDropSite({ location_id: dropSiteId, ...dropSite })
-        .then((data) => {
-          setSent(true);
-        });
-    }
-
-    backend.addNewDropSite(dropSite).then((data) => {
-      if (!data) {
-        return;
-      }
-      setSent(true);
-      setDropSiteId(data);
-    });
-  };
-
-  if (loading) {
-    return null;
-  }
-
-  if (sent && dropSite.location_id) {
-    return (
-      <Page currentProgress={2} totalProgress={5}>
-        <Form
-          onSubmit={() =>
-            history.push(
-              routeWithParams(Routes.SIGNUP_DROPSITE, {
-                id: dropSite.location_id,
-              }),
-            )
-          }
-        >
-          <FacilityConfirmation
-            onEdit={() => setSent(false)}
-            name={dropSite.dropSiteFacilityName}
-            address={[
-              dropSite.dropSiteAddress,
-              dropSite.dropSiteCity,
-              dropSite.dropSiteState,
-              dropSite.dropSiteZip,
-            ].join(', ')}
-          />
-        </Form>
-      </Page>
-    );
-  }
-
+function NewFacility({ backend }) {
   return (
     <Page currentProgress={2} totalProgress={5}>
-      <FacilityForm handleSubmit={handleSubmit} dropSite={dropSite} />
+      <FacilityForm backend={backend} />
     </Page>
   );
 }
 
-export default withRouter(NewFacility);
+export default NewFacility;


### PR DESCRIPTION
Closes this https://app.clubhouse.io/helpsupply/story/33/move-edit-facility-screen-to-unique-route
Makes progress on this https://app.clubhouse.io/helpsupply/story/34/move-confirmation-screens-to-unique-routes

Here we are adding unique routes for the facility confirmation and edit screens which allows for the page navigation to work a bit better (you can refresh or go back successfully now). I also moved the facility form logic into that container component instead of the facility page.