### PR TITLE
Chore: remove kebab-case warning

### DIFF
--- a/src/components/Autosuggest/Autosuggest.styles.js
+++ b/src/components/Autosuggest/Autosuggest.styles.js
@@ -75,7 +75,7 @@ const styles = {
       marginBottom: Space.S0,
       maxHeight: '250px',
       overflow: 'scroll',
-      '-webkit-overflow-scrolling': 'touch',
+      WebkitOverflowScrolling: 'touch',
       padding: `0 ${Space.S20}px`,
 
       '> li': {


### PR DESCRIPTION
Just squashing a warning. Verified that overflowScroll still works on the AutoSuggest component for the facility page.

<img width="831" alt="Screenshot 2020-04-02 11 22 57" src="https://user-images.githubusercontent.com/1128500/78284554-713e0480-74d4-11ea-98ab-1fc30d6d82b8.png">
