### PR TITLE
Chore: no-throw-literal warnings

### DIFF
--- a/src/lib/backendInterface.js
+++ b/src/lib/backendInterface.js
@@ -3,12 +3,12 @@ class BackendInterface {
 
   listDropSites(zipcode, radius) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   getDropSites(dropSiteId) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   addDropSite(
@@ -19,7 +19,7 @@ class BackendInterface {
     dropSiteZip,
   ) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   editDropSite(
@@ -29,14 +29,14 @@ class BackendInterface {
     dropSiteZip,
   ) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   // REQUESTS
 
   getRequests(dropSiteId, requestType, status) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   addRequest(
@@ -48,7 +48,7 @@ class BackendInterface {
     status,
   ) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   editRequest(
@@ -60,52 +60,52 @@ class BackendInterface {
     status,
   ) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   isLoggedIn() {
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   async isValidHealthcareWorker() {
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   // VALIDATED DOMAINS
 
   getPendingDomains() {
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   setDomainIsValid(domain, isValid) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   // HEALTH CARE PROFESSIONALS AND ADMINS
 
   signupWithEmail(email) {
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   addHealthcareProfessional(userId) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   editHealthcareProfessional(hcpId, valid) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   addDropSiteAdmin(userId, dropSiteId) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 
   removeDropSiteAdmin(userId, dropSiteId) {
     // Abstract
-    throw 'Abstract Interface';
+    throw new Error('Abstract Interface');
   }
 }
 

--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -483,7 +483,7 @@ class FirebaseBackend extends BackendInterface {
       window.localStorage.removeItem('emailForSignIn');
       window.testfs = this.firestore;
     } else {
-      throw 'Email Link Invalid';
+      throw new Error('Email Link Invalid');
     }
   }
 
@@ -528,7 +528,7 @@ class FirebaseBackend extends BackendInterface {
         .doc(domain)
         .set({ valid: isValid ? 'true' : 'false' });
     } catch (e) {
-      throw 'Validating domains is not allowed';
+      throw new Error('Validating domains is not allowed');
     }
   }
 


### PR DESCRIPTION
Syntax update to clear out some error reporting warnings.

<img width="1012" alt="Screenshot 2020-04-02 11 32 21" src="https://user-images.githubusercontent.com/1128500/78287058-eeb64480-74d5-11ea-8337-9555ccc2becb.png">
