### PR TITLE
chore(signup): add signup confirmation screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import NewDropSite from 'pages/dropsite_new';
 import EntryPortal from 'pages/entry';
 import Request from 'pages/request';
 import SignUp from 'pages/signup';
+import SignUpConfirmation from 'pages/signup_confirmation';
 
 import HCPSignupFinish from 'components/HCPSignupFinish';
 import DropSite from 'components/DropSite';
@@ -135,8 +136,11 @@ function App({ backend }) {
             <Route path={Routes.REQUEST_SUPPLIES}>
               <Request backend={backend} />
             </Route>
-            <Route path={Routes.SIGNUP_DROPSITE}>
+            <Route exact path={Routes.SIGNUP_DROPSITE}>
               <SignUp backend={backend} />
+            </Route>
+            <Route exact path={Routes.SIGNUP_DROPSITE_CONFIRMATION}>
+              <SignUpConfirmation backend={backend} />
             </Route>
             <Route exact path={Routes.NEW_FACILITY}>
               <NewFacility backend={backend} />

--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -16,7 +16,8 @@ export const Routes = {
   REQUEST_SERVICES: '/request-services',
   REQUEST_SUPPLIES: '/request',
   SIGNUP_DROPSITE: `/signup/:id`,
-  SIGNUP_FINISH_DROPSITE: `/signupFinish/:id`,
+  SIGNUP_DROPSITE_CONFIRMATION: `/signup/:id/confirmation`,
+  SIGNUP_FINISH_DROPSITE: `/signup/finish/:id`,
   STYLE_GUIDE: '/style-guide',
   SUPPLY_NEW_ADMIN: `/new/admin/supply/:id`,
 };

--- a/src/containers/EmailForm.js
+++ b/src/containers/EmailForm.js
@@ -2,32 +2,37 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { jsx } from '@emotion/core';
+import { useHistory, useParams } from 'react-router-dom';
 
 import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
 import { isValidEmail } from 'lib/utils/validations';
 
 import Note from 'components/Note';
 import Anchor, { anchorTypes } from 'components/Anchor';
-import HeaderInfo from 'components/Form/HeaderInfo';
+
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
-const validate = (val) => {
-  if (!isValidEmail(val)) {
-    return 'Please enter a valid email address';
-  }
-};
-
-function EmailForm({ backend, match }) {
+function EmailForm({ backend }) {
+  const history = useHistory();
+  const params = useParams();
   const { t } = useTranslation();
+
   const [email, setEmail] = useState('');
-  const [sent, setSent] = useState(false);
+
   const [isLoading, setIsLoading] = useState(false);
-  const [dropSite, setDropSite] = useState(match.params.id);
+  const [dropSite, setDropSite] = useState(params.id);
 
   useEffect(() => {
-    setDropSite(match.params.id);
-  }, [match.params.id]);
+    setDropSite(params.id);
+  }, [params.id]);
+
+  const validate = (val) => {
+    if (!isValidEmail(val)) {
+      return t('request.workEmailForm.workEmail.validation.label');
+    }
+  };
 
   const handleSubmit = () => {
     setIsLoading(true);
@@ -35,8 +40,11 @@ function EmailForm({ backend, match }) {
     backend
       .signupWithEmail(email, dropSite)
       .then(() => {
-        setSent(true);
-        setIsLoading(false);
+        history.push(
+          routeWithParams(Routes.SIGNUP_DROPSITE_CONFIRMATION, {
+            id: params.id,
+          }),
+        );
       })
       .catch((error) => {
         console.error('error', error);
@@ -44,15 +52,6 @@ function EmailForm({ backend, match }) {
       });
     // TODO: handle exceptions
   };
-
-  if (sent) {
-    return (
-      <HeaderInfo
-        title={t('request.workEmailForm.sent.title')}
-        description={t('request.workEmailForm.sent.description')}
-      />
-    );
-  }
 
   const fieldData = [
     {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -62,6 +62,7 @@
     "request.workEmailForm.title": "Enter your work email address",
     "request.workEmailForm.workEmail.label": "Work email",
     "request.workEmailForm.workEmail.disclaimer": "Note: we will never share your email address with any other parties.",
+    "request.workEmailForm.workEmail.validation.label": "Please enter a valid email address",
     "request.dropSiteContactForm.title": "Contact info",
     "request.dropSiteContactForm.description": "Enter the contact information for the person coordinating supplies at your facility.",
     "request.dropSiteContactForm.name.label": "Name",

--- a/src/pages/signup.js
+++ b/src/pages/signup.js
@@ -1,16 +1,15 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import { withRouter } from 'react-router-dom';
 
 import Page from 'components/layouts/Page';
 import EmailForm from 'containers/EmailForm';
 
-function SignUp(props) {
+function SignUp({ backend }) {
   return (
     <Page currentProgress={3} totalProgress={5}>
-      <EmailForm {...props} />
+      <EmailForm backend={backend} />
     </Page>
   );
 }
 
-export default withRouter(SignUp);
+export default SignUp;

--- a/src/pages/signup_confirmation.js
+++ b/src/pages/signup_confirmation.js
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { useTranslation } from 'react-i18next';
+
+import Page from 'components/layouts/Page';
+import HeaderInfo from 'components/Form/HeaderInfo';
+
+function SignUp(props) {
+  const { t } = useTranslation();
+
+  return (
+    <Page hasBackButton={false}>
+      <HeaderInfo
+        title={t('request.workEmailForm.sent.title')}
+        description={t('request.workEmailForm.sent.description')}
+      />
+    </Page>
+  );
+}
+
+export default SignUp;


### PR DESCRIPTION
More progress here: https://app.clubhouse.io/helpsupply/story/34/move-confirmation-screens-to-unique-routes

Adds unique route for signup confirmation. Also exchanges the `withRouter` HOC for `useHistory` and `useParams` hooks (which I've been doing everywhere).