### PR TITLE
feat(state): add simple state machine

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,8 @@ import { useTranslation } from 'react-i18next';
 
 import { Routes } from 'constants/Routes';
 
+import { StateProvider } from 'state/StateProvider';
+
 import NewSupplyRequest from 'pages/supplies_new';
 import NewSupplyRequestConfirmation from 'pages/supplies_new_confirmation';
 import AdminDropSite from 'pages/dropsite_admin';
@@ -31,6 +33,8 @@ import StyleGuide from 'components/StyleGuide/index';
 import Box from 'components/Box';
 import InvalidEmail from 'components/Alert/InvalidEmail';
 import Loading from 'components/Loading';
+
+import { actions } from 'state/StateProvider';
 
 import { styles } from './App.styles';
 
@@ -82,7 +86,7 @@ const ProtectedRoute = ({ backend, children, path }) => {
 
 function App({ backend }) {
   return (
-    <>
+    <StateProvider>
       <Global styles={styles} />
       <Router>
         <div className="App">
@@ -160,16 +164,16 @@ function App({ backend }) {
             <Route exact path={Routes.FACILITY_CONFIRMATION}>
               <FacilityConfirmation backend={backend} />
             </Route>
-            <Route exact path={Routes.FACILITY_EDIT}>
+            <ProtectedRoute exact path={Routes.FACILITY_EDIT} backend={backend}>
               <FacilityEdit backend={backend} />
-            </Route>
+            </ProtectedRoute>
             <Route path="*">
               <NoMatch />
             </Route>
           </Switch>
         </div>
       </Router>
-    </>
+    </StateProvider>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -34,8 +34,6 @@ import Box from 'components/Box';
 import InvalidEmail from 'components/Alert/InvalidEmail';
 import Loading from 'components/Loading';
 
-import { actions } from 'state/StateProvider';
-
 import { styles } from './App.styles';
 
 const ProtectedRoute = ({ backend, children, path }) => {

--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -4,7 +4,7 @@ export const Routes = {
   DROPSITE_CONTACT_CONFIRMATION: `/dropsite/:id/contact/confirmation`,
   DROPSITE_DETAIL: `/dropsite/:id`,
   DROPSITE_NEW_ADMIN: `/dropsite/new/admin/:id`,
-  FACILITY_CONFIRMATION: '/facility/:id/confirmation',
+  FACILITY_CONFIRMATION: '/facility/confirmation',
   FACILITY_EDIT: '/facility/:id/edit',
   FAQ: '/faq',
   HOME: '/',

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -5,10 +5,10 @@ import { jsx } from '@emotion/core';
 import { useHistory } from 'react-router-dom';
 
 import { Routes } from 'constants/Routes';
-import { routeWithParams } from 'lib/utils/routes';
 import { Emails } from 'constants/Emails';
 
 import states from 'data/states';
+import { useStateValue, actions } from 'state/StateProvider';
 
 import Anchor, { anchorTypes } from 'components/Anchor';
 import Note from 'components/Note';
@@ -18,6 +18,7 @@ import { formFieldTypes } from 'components/Form/CreateFormFields';
 function FacilityForm({ backend, dropSite, dropSiteId }) {
   const { t } = useTranslation();
   const history = useHistory();
+  const dispatch = useStateValue()[1];
 
   const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState({
@@ -36,9 +37,11 @@ function FacilityForm({ backend, dropSite, dropSiteId }) {
       return backend
         .editDropSite({ location_id: dropSiteId, ...fields })
         .then((data) => {
-          history.push(
-            routeWithParams(Routes.FACILITY_CONFIRMATION, { id: dropSiteId }),
-          );
+          dispatch({
+            type: actions.ADD_PENDING_FACILITY,
+            pendingFacility: { location_id: dropSiteId, ...fields },
+          });
+          history.push(Routes.FACILITY_CONFIRMATION);
         });
     }
 
@@ -47,7 +50,11 @@ function FacilityForm({ backend, dropSite, dropSiteId }) {
         return;
       }
 
-      history.push(routeWithParams(Routes.FACILITY_CONFIRMATION, { id: data }));
+      dispatch({
+        type: actions.ADD_PENDING_FACILITY,
+        pendingFacility: { location_id: data, ...fields },
+      });
+      history.push(Routes.FACILITY_CONFIRMATION);
     });
   };
 

--- a/src/pages/facility_confirmation.js
+++ b/src/pages/facility_confirmation.js
@@ -1,48 +1,41 @@
 /** @jsx jsx */
-import { useEffect, useState } from 'react';
 import { jsx } from '@emotion/core';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory } from 'react-router-dom';
 
 import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
+import { useStateValue } from 'state/StateProvider';
 
 import Page from 'components/layouts/Page';
 import PageLoader from 'components/Loader/PageLoader';
 import { FacilityConfirmation as FacilityConfirmationComponent } from 'components/Confirmation';
 
-function FacilityConfirmation({ backend }) {
+function FacilityConfirmation() {
   const history = useHistory();
-  const params = useParams();
+  const [{ pendingFacility }] = useStateValue();
 
-  const [isLoading, setIsLoading] = useState(true);
-  const [dropSite, setDropSite] = useState();
-
-  useEffect(() => {
-    backend.getDropSites(params.id).then((data) => {
-      setDropSite(data);
-      setIsLoading(false);
-    });
-  }, [backend, params.id]);
+  const hasPendingFacility =
+    !!pendingFacility && !!Object.keys(pendingFacility).length;
 
   const handleOnEdit = () => {
     history.push(
       routeWithParams(Routes.FACILITY_EDIT, {
-        id: dropSite.location_id,
+        id: pendingFacility.location_id,
       }),
     );
   };
 
   return (
     <Page currentProgress={2} totalProgress={5}>
-      {isLoading && <PageLoader />}
-      {!isLoading && (
+      {!hasPendingFacility && <PageLoader />}
+      {hasPendingFacility && (
         <FacilityConfirmationComponent
           onEdit={handleOnEdit}
-          name={dropSite.dropSiteFacilityName}
-          streetAddress={dropSite.dropSiteAddress}
-          city={dropSite.dropSiteCity}
-          state={dropSite.dropSiteState}
-          zip={dropSite.dropSiteZip}
+          name={pendingFacility.dropSiteFacilityName}
+          streetAddress={pendingFacility.dropSiteAddress}
+          city={pendingFacility.dropSiteCity}
+          state={pendingFacility.dropSiteState}
+          zip={pendingFacility.dropSiteZip}
         />
       )}
     </Page>

--- a/src/pages/facility_edit.js
+++ b/src/pages/facility_edit.js
@@ -14,10 +14,16 @@ function FacilityEdit({ backend }) {
   const [dropSite, setDropSite] = useState();
 
   useEffect(() => {
-    backend.getDropSites(params.id).then((data) => {
-      setDropSite(data);
-      setIsLoading(false);
-    });
+    backend
+      .getDropSites(params.id)
+      .then((data) => {
+        setDropSite(data);
+        setIsLoading(false);
+      })
+      .catch((error) => {
+        console.error('error', error);
+        setIsLoading(false);
+      });
   }, [backend, params.id]);
 
   return (

--- a/src/state/StateProvider.js
+++ b/src/state/StateProvider.js
@@ -1,0 +1,17 @@
+import React, { createContext, useContext, useReducer } from 'react';
+
+import { reducer, initialState } from './reducer';
+
+export const actions = {
+  ADD_PENDING_FACILITY: 'ADD_PENDING_FACILITY',
+};
+
+export const StateContext = createContext();
+
+export const StateProvider = ({ children }) => (
+  <StateContext.Provider value={useReducer(reducer, initialState)}>
+    {children}
+  </StateContext.Provider>
+);
+
+export const useStateValue = () => useContext(StateContext);

--- a/src/state/persistState.js
+++ b/src/state/persistState.js
@@ -1,0 +1,18 @@
+const stateKey = 'state';
+
+export const persistState = (state, action) => {
+  const actionDataKey = Object.keys(action).find((key) => key !== 'type');
+  const actionData = action[actionDataKey];
+
+  const newState = { ...state, [actionDataKey]: { ...actionData } };
+  const stringifiedState = JSON.stringify(newState);
+
+  localStorage.setItem(stateKey, stringifiedState);
+};
+
+export const getPersistedState = () => {
+  const stateString = localStorage.getItem(stateKey);
+  return JSON.parse(stateString);
+};
+
+export const clearPersistedState = () => localStorage.removeItem(stateKey);

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -1,10 +1,15 @@
+import { getPersistedState, persistState } from './persistState';
 import { actions } from './StateProvider';
 
-export const initialState = {
+const persistedState = getPersistedState();
+
+export const initialState = persistedState || {
   pendingFacility: {},
 };
 
 export const reducer = (state, action) => {
+  persistState(state, action);
+
   switch (action.type) {
     case actions.ADD_PENDING_FACILITY:
       return {

--- a/src/state/reducer.js
+++ b/src/state/reducer.js
@@ -1,0 +1,18 @@
+import { actions } from './StateProvider';
+
+export const initialState = {
+  pendingFacility: {},
+};
+
+export const reducer = (state, action) => {
+  switch (action.type) {
+    case actions.ADD_PENDING_FACILITY:
+      return {
+        ...state,
+        pendingFacility: action.pendingFacility,
+      };
+
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
We're using a combination of context and hooks to maintain a simple global state that is a little reduxy. This includes a little bit of middleware to persist our state data to localhost. That part is fairly bare at this point and we need to give some thought to what data we want to persist and when we should clear it, but the outline of an idea is in here.

fetch state:
`const [ state ] = useStateValue();` or `const [{ pieceOfState }] = useStateValue();`

set state:
```
import { useStateValue, actions } from 'state/StateProvider';

function MyComponent() {
  const dispatch = useStateValue()[1]; OR const [state, dispatch] = useStateValue();

  {...more code and stuff}

  const handleSomeAction = () => {
    ...doing some stuff
    dispatch({
      type: actions.ADD_PENDING_FACILITY,
      pendingFacility: { ...data },
    });
  }
}
```