### PR TITLE
Refactor: signup finish page

### DIFF
--- a/src/components/HCPSignupFinish.js
+++ b/src/components/HCPSignupFinish.js
@@ -1,114 +1,157 @@
-import React from 'react';
-import Firebase from 'firebase';
-import * as firebaseui from 'firebaseui';
-import { withRouter } from 'react-router-dom';
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { useTranslation } from 'react-i18next';
+import { useCallback, useEffect, useState } from 'react';
+import { useHistory, useParams } from 'react-router-dom';
+
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
+import { isValidEmail } from 'lib/utils/validations';
 
-class HCPSignupFinish extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      email: '',
-      confirmEmail: false,
-      dropsite: this.props.match.params.id,
-    };
-    this.ui = new firebaseui.auth.AuthUI(Firebase.auth());
+import { useLoggedIn } from 'hooks/useLoggedIn';
 
-    this.submitEmail = this.submitEmail.bind(this);
-    this.handleEmailChange = this.handleEmailChange.bind(this);
-  }
+import Page from 'components/layouts/Page';
+import PageLoader from 'components/Loader/PageLoader';
+import Note from 'components/Note';
+import Anchor, { anchorTypes } from 'components/Anchor';
 
-  componentDidMount() {
-    const shouldConfirm = this.props.backend.shouldRepromptEmail();
-    this.setState({ confirmEmail: shouldConfirm });
-    if (shouldConfirm === false) {
-      this.submitEmail();
+function HCPSignupFinish({ backend }) {
+  const { loggedIn } = useLoggedIn();
+  const history = useHistory();
+  const params = useParams();
+  const { t } = useTranslation();
+
+  const [email, setEmail] = useState('');
+  const [shouldConfirmEmail, setShouldConfirmEmail] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const { id: dropsite } = params;
+
+  useEffect(() => {
+    if (loggedIn && dropsite) {
+      history.push(
+        routeWithParams(Routes.DROPSITE_ADMIN, {
+          id: dropsite,
+        }),
+      );
     }
-  }
+  }, [loggedIn, history, dropsite]);
 
-  submitEmail(event) {
-    if (event) {
-      event.preventDefault();
-    }
-    let url = window.location.href;
-    let hasAddress;
-    this.props.backend
-      .continueSignup(url, this.state.confirmEmail ? this.state.email : null)
-      .then(() => {
-        this.props.backend
-          .getDropSites(this.state.dropsite)
-          .then((data) => {
-            hasAddress = !!data.dropSiteAddress;
-            if (!hasAddress) {
-              this.props.history.push(
-                routeWithParams(Routes.DROPSITE_NEW_ADMIN, {
-                  id: this.state.dropsite,
-                }),
-              );
-            }
-          })
-          .then(() => {
-            if (!hasAddress) {
-              return;
-            }
-            this.props.backend
-              .getRequests(this.state.dropsite)
-              .then((requests) => {
+  const handleSubmit = useCallback(
+    ({ email }) => {
+      if (backend.authLoaded && backend.isLoggedIn()) {
+        history.push(
+          routeWithParams(Routes.DROPSITE_ADMIN, {
+            id: dropsite,
+          }),
+        );
+      }
+
+      if (!email) {
+        return;
+      }
+
+      let url = window.location.href;
+      let hasAddress;
+
+      backend
+        .continueSignup(url, shouldConfirmEmail ? email : null)
+        .then(() => {
+          backend
+            .getDropSites(dropsite)
+            .then((data) => {
+              hasAddress = !!data.dropSiteAddress;
+              if (!hasAddress) {
+                history.push(
+                  routeWithParams(Routes.DROPSITE_NEW_ADMIN, {
+                    id: dropsite,
+                  }),
+                );
+              }
+            })
+            .then(() => {
+              if (!hasAddress) {
+                return;
+              }
+              backend.getRequests(dropsite).then((requests) => {
                 if (requests?.length) {
-                  this.props.history.push(
+                  history.push(
                     routeWithParams(Routes.DROPSITE_ADMIN, {
-                      id: this.state.dropsite,
+                      id: dropsite,
                     }),
                   );
                   return;
                 }
 
-                this.props.history.push(
+                history.push(
                   routeWithParams(Routes.SUPPLY_NEW_ADMIN, {
-                    dropsite: this.state.dropsite,
+                    dropsite: dropsite,
                   }),
                 );
               });
-          });
-      });
-  }
+            });
+        })
+        .catch((error) => {
+          console.error('error', error);
+          setIsLoading(false);
+          // todo: handle this error
+        });
+    },
+    [backend, shouldConfirmEmail, dropsite, history],
+  );
 
-  handleEmailChange(event) {
-    this.setState({ email: event.target.value });
-  }
+  useEffect(() => {
+    const emailForSignIn = backend.getEmailForSignIn();
+    setShouldConfirmEmail(emailForSignIn === null);
+    if (!shouldConfirmEmail) {
+      handleSubmit({ email: emailForSignIn });
+      return;
+    }
+    setIsLoading(false);
+  }, [backend, handleSubmit, shouldConfirmEmail]);
 
-  render() {
-    return (
-      <div className="homeBox">
-        <div className="verifyContainer container-sm">
-          {this.state.confirmEmail === true ? (
-            <div>
-              <h2>Please enter your email, once more</h2>
-              <form className="linkSubmitGroup" onSubmit={this.submitEmail}>
-                <input
-                  className="linkTitle form-control"
-                  id="linkTitle"
-                  placeholder="Your email, once more"
-                  value={this.state.email}
-                  onChange={this.handleEmailChange}
-                />
-                <button
-                  className="btn btn-primary linkSubmitBtn"
-                  onClick={this.submitEmail}
-                >
-                  Submit
-                </button>
-              </form>
-            </div>
-          ) : (
-            <h2>Logging you in!</h2>
-          )}
-        </div>
-      </div>
-    );
-  }
+  const validate = (val) => {
+    if (!isValidEmail(val)) {
+      return t('request.workEmailForm.workEmail.validation.label');
+    }
+  };
+
+  const fieldData = [
+    {
+      customOnChange: setEmail,
+      label: t('request.workEmailForm.workEmail.label'),
+      name: 'email',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate },
+    },
+  ];
+
+  return (
+    <Page currentProgress={3} totalProgress={5}>
+      {isLoading && <PageLoader />}
+      {!isLoading && (
+        <FormBuilder
+          defaultValues={{ email: '' }}
+          onSubmit={handleSubmit}
+          title={t('request.workEmailForm.finish.title')}
+          description={t('request.workEmailForm.description')}
+          disabled={!isValidEmail(email)}
+          isLoading={isLoading}
+          fields={fieldData}
+        >
+          <Note>
+            {t('request.workEmailForm.workEmail.disclaimer') + ' '}
+            <Anchor href={Routes.HOME} as={anchorTypes.A}>
+              {t('request.workEmailForm.learnMore')}
+            </Anchor>
+          </Note>
+        </FormBuilder>
+      )}
+    </Page>
+  );
 }
 
-export default withRouter(HCPSignupFinish);
+export default HCPSignupFinish;

--- a/src/hooks/useLoggedIn.js
+++ b/src/hooks/useLoggedIn.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+
+export const useLoggedIn = () => {
+  const [user, setUser] = useState({ loggedIn: false });
+
+  useEffect(() => {
+    const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
+      if (user) {
+        setUser({ loggedIn: true, email: user.email });
+      } else {
+        setUser({ loggedIn: false });
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  return user;
+};

--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -465,15 +465,30 @@ class FirebaseBackend extends BackendInterface {
     window.localStorage.setItem('emailForSignIn', email);
   }
 
-  shouldRepromptEmail() {
-    return window.localStorage.getItem('emailForSignIn') === null;
+  getEmailForSignIn() {
+    return window.localStorage.getItem('emailForSignIn');
   }
 
-  async continueSignup(url, email, dropsite) {
+  async continueSignup(url, email) {
     if (this.firebase.auth().isSignInWithEmailLink(url)) {
-      var emailOrStoredEmail =
-        window.localStorage.getItem('emailForSignIn') || email;
-      await this.firebase.auth().signInWithEmailLink(emailOrStoredEmail, url);
+      const emailOrStoredEmail =
+        email || window.localStorage.getItem('emailForSignIn');
+
+      await this.firebase
+        .auth()
+        .signInWithEmailLink(emailOrStoredEmail, url)
+        .then((result) => {
+          if (process.env.NODE_ENV !== 'production') {
+            console.log(result);
+          }
+        })
+        .catch((err) => {
+          if (process.env.NODE_ENV !== 'production') {
+            console.error(err);
+          }
+          throw new Error('Email Link Invalid');
+        });
+
       window.localStorage.removeItem('emailForSignIn');
       window.testfs = this.firestore;
     } else {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,7 @@
     "request.workEmailForm.workEmail.label": "Work email",
     "request.workEmailForm.workEmail.disclaimer": "Note: we will never share your email address with any other parties.",
     "request.workEmailForm.workEmail.validation.label": "Please enter a valid email address",
+    "request.workEmailForm.finish.title": "Please enter your email, once more",
     "request.dropSiteContactForm.title": "Contact info",
     "request.dropSiteContactForm.description": "Enter the contact information for the person coordinating supplies at your facility.",
     "request.dropSiteContactForm.name.label": "Name",


### PR DESCRIPTION
Sort of related to this:
https://app.clubhouse.io/helpsupply/story/29/loading-screen-logging-you-in-screen

Did some refactoring for the `signup/finish` url that get's emailed to you and learned a few things. This could probably be further broken out into more components and pages, but wanted to get the progress up here for discussion/feedback.

* When you submit your email from the supply signup page (e.g. `signup/50441`) a localStorage object `emailForSignIn` gets saved
* When click the link in your email, you go to the `signup/finish` page
  * If you're completing this process on a different browser, or for some reason the localStorage object isn't set, you're prompted to enter your email again "Please enter your email, once more"
* Added some error handling to the `continueSignup` method so it bubbles up to the front-end and we can communicate to the user
* Added a `useLoggedIn` hook that's wired up to Firebase
  * If someone somehow ends up on the `signup/finish` page and they're all logged in, we can just redirect them to the dropsite admin page (e.g. `dropsite/50441/admin`)

<img width="375" alt="Screenshot 2020-04-02 22 08 48" src="https://user-images.githubusercontent.com/1128500/78327106-ed663580-7530-11ea-915b-2d9b0d671d2d.png">
