### PR TITLE
Check logged-in state using hook, redirect to home if not logged in

### DIFF
--- a/src/components/HCPSignupFinish.js
+++ b/src/components/HCPSignupFinish.js
@@ -11,7 +11,7 @@ import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
 import { isValidEmail } from 'lib/utils/validations';
 
-import { useLoggedIn } from 'hooks/useLoggedIn';
+import { useAuth } from 'hooks/useAuth';
 
 import Page from 'components/layouts/Page';
 import PageLoader from 'components/Loader/PageLoader';
@@ -19,7 +19,7 @@ import Note from 'components/Note';
 import Anchor, { anchorTypes } from 'components/Anchor';
 
 function HCPSignupFinish({ backend }) {
-  const { loggedIn } = useLoggedIn();
+  const { isLoggedIn } = useAuth();
   const history = useHistory();
   const params = useParams();
   const { t } = useTranslation();
@@ -31,14 +31,14 @@ function HCPSignupFinish({ backend }) {
   const { id: dropsite } = params;
 
   useEffect(() => {
-    if (loggedIn && dropsite) {
+    if (isLoggedIn && dropsite) {
       history.push(
         routeWithParams(Routes.DROPSITE_ADMIN, {
           id: dropsite,
         }),
       );
     }
-  }, [loggedIn, history, dropsite]);
+  }, [isLoggedIn, history, dropsite]);
 
   const handleSubmit = useCallback(
     ({ email }) => {

--- a/src/hooks/useAuth.js
+++ b/src/hooks/useAuth.js
@@ -2,16 +2,20 @@ import { useEffect, useState } from 'react';
 import firebase from 'firebase/app';
 import 'firebase/auth';
 
-export const useLoggedIn = () => {
-  const [user, setUser] = useState({ loggedIn: false });
+export const useAuth = () => {
+  const [auth, setAuth] = useState({
+    isInitializing: true,
+    isLoggedIn: false,
+    user: null,
+  });
 
   useEffect(() => {
     const unsubscribe = firebase.auth().onAuthStateChanged((user) => {
-      if (user) {
-        setUser({ loggedIn: true, email: user.email });
-      } else {
-        setUser({ loggedIn: false });
-      }
+      setAuth({
+        isInitializing: false,
+        isLoggedIn: user !== null,
+        user: user,
+      });
     });
 
     return () => {
@@ -19,5 +23,5 @@ export const useLoggedIn = () => {
     };
   }, []);
 
-  return user;
+  return auth;
 };


### PR DESCRIPTION
Related to this:
https://app.clubhouse.io/helpsupply/story/29/loading-screen-logging-you-in-screen

* Updated `ProtectedRoute` to use the `useLoggedIn` hook.
* Once the app connects to the backed (`useLoggedIn -> loaded`) and if the `loggedIn` status is false, redirect the user to `HOME`.