### PR TITLE
Fix: remove simplistic already logged-in effect, use routing logic

### DIFF
--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -61,6 +61,9 @@ class FirebaseBackend extends BackendInterface {
         .collection('dropSite')
         .doc(dropSiteId)
         .get();
+      if (!doc.exists) {
+        return false;
+      }
       let dropsite = doc.data();
       return (await this._checkValidity([dropsite]))[0];
     } else {


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/95/blank-drop-off-location-page

A previous change was sending logged-in users to the dropsite admin page which isn't totally correct. 

* If a facility doesn't have a dropsite yet, send them to the `new dropsite page`. 
* If a dropsite exists be there are no requests, send them to the `new supplies request page`.
* Otherwise, send them to the `admin page`.