### PR TITLE
Fix onSuggestionsClearRequested warning

### DIFF
--- a/src/components/Autosuggest/index.js
+++ b/src/components/Autosuggest/index.js
@@ -10,6 +10,7 @@ function Autosuggest({
   label,
   onSearch,
   onSelect,
+  onSuggestionsClearRequested,
   renderSuggestion,
   suggestions,
 }) {
@@ -68,6 +69,7 @@ function Autosuggest({
         suggestions={suggestions}
         onSuggestionsFetchRequested={onSuggestionsFetchRequested}
         getSuggestionValue={getSuggestionValue}
+        onSuggestionsClearRequested={onSuggestionsClearRequested}
         onSuggestionSelected={onSuggestionSelect}
         renderSuggestion={renderSuggestion}
         inputProps={inputProps}
@@ -79,6 +81,7 @@ function Autosuggest({
 Autosuggest.propTypes = {
   getSuggestionValue: PropTypes.func.isRequired,
   onSearch: PropTypes.func.isRequired,
+  onSuggestionsClearRequested: PropTypes.func.isRequired,
   renderSuggestion: PropTypes.func.isRequired,
   suggestions: PropTypes.array.isRequired,
 };

--- a/src/containers/FindFacility.js
+++ b/src/containers/FindFacility.js
@@ -104,7 +104,7 @@ function FindFacility({ backend, history }) {
       .dropSiteExists(selectedResult)
       .then((exists) => {
         if (!exists) {
-          // create dropsite with corresponding facilty id and info
+          // create dropsite with corresponding facility id and info
           backend.addDropSite({
             location_id: selectedResult,
             dropSiteFacilityName: facility.name,
@@ -149,6 +149,7 @@ function FindFacility({ backend, history }) {
         onSearch={handleChange}
         getSuggestionValue={getHospitalName}
         renderSuggestion={renderSuggestion}
+        onSuggestionsClearRequested={() => setSelectedResult('')}
         onSelect={setSelectedResult}
       />
       <Text type={TEXT_TYPE.BODY_2}>


### PR DESCRIPTION
In local development on the `/request` page, this fix clears `Warning: Failed prop type: 'onSuggestionsClearRequested' must be implemented.`