### PR TITLE
Fix onSuggestionsClearRequested warning - part 2

### DIFF
--- a/src/containers/FindFacility.js
+++ b/src/containers/FindFacility.js
@@ -149,7 +149,7 @@ function FindFacility({ backend, history }) {
         onSearch={handleChange}
         getSuggestionValue={getHospitalName}
         renderSuggestion={renderSuggestion}
-        onSuggestionsClearRequested={() => setSelectedResult('')}
+        onSuggestionsClearRequested={() => null}
         onSelect={setSelectedResult}
       />
       <Text type={TEXT_TYPE.BODY_2}>


### PR DESCRIPTION
The previous `onSuggestionsClearRequested` fix actually gets called everytime the autosuggest drawer closes, so clearing the state broke the page. It's a required function for that component, so a `null` return function solves the warning, and we don't need to do anything special when the drawer closes.