### PR TITLE
Latest flow updates

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,9 +27,10 @@ import Request from 'pages/request';
 
 // MVP
 import EntryPortal from 'pages/entry';
+import Facility from 'pages/facility';
 import SignUp from 'pages/signup';
 import SignUpConfirmation from 'pages/signup_confirmation';
-import SignupFinish from 'pages/signup_approve';
+import SignupComplete from 'pages/signup_approve';
 import Contact from 'pages/contact';
 import ContactConfirmation from 'pages/contact_confirmation';
 import ServiceType from 'pages/service_type';
@@ -91,7 +92,7 @@ const ProtectedRoute = ({ backend, children, path }) => {
     );
   }
 
-  // TODO: check if this accounts for mismatched validation, ie email does not match facility
+  // service/supply TODO: check if this accounts for mismatched validation, ie email does not match facility
   if (!verified && badDomain) {
     content = (
       <Box>
@@ -114,14 +115,17 @@ function App({ backend }) {
             <Route exact path={Routes.HOME}>
               <EntryPortal backend={backend} />
             </Route>
-            <Route exact path={Routes.EMAIL_FORM}>
+            <Route exact path={Routes.FACILITY}>
+              <Facility backend={backend} />
+            </Route>
+            <Route exact path={Routes.EMAIL_SIGNUP_FORM}>
               <SignUp backend={backend} />
             </Route>
-            <Route exact path={Routes.EMAIL_SENT}>
+            <Route exact path={Routes.EMAIL_SIGNUP_SENT}>
               <SignUpConfirmation backend={backend} />
             </Route>
-            <Route exact path={Routes.EMAIL_APPROVE}>
-              <SignupFinish backend={backend} />
+            <Route exact path={Routes.EMAIL_SIGNUP_COMPLETE}>
+              <SignupComplete backend={backend} />
             </Route>
             <ProtectedRoute backend={backend} exact path={Routes.CONTACT_FORM}>
               <Contact backend={backend} />

--- a/src/App.js
+++ b/src/App.js
@@ -34,6 +34,8 @@ import SignupComplete from 'pages/signup_approve';
 import Contact from 'pages/contact';
 import ContactConfirmation from 'pages/contact_confirmation';
 import ServiceType from 'pages/service_type';
+import ServiceGrocery from 'pages/service_grocery';
+import ServiceAdditionalInfo from 'pages/service_additional_info';
 import LearnMore from 'pages/learn_more';
 // End MVP
 
@@ -140,9 +142,42 @@ function App({ backend }) {
             <ProtectedRoute backend={backend} exact path={Routes.SERVICE_TYPE}>
               <ServiceType backend={backend} />
             </ProtectedRoute>
+            <ProtectedRoute
+              backend={backend}
+              exact
+              path={Routes.SERVICE_GROCERIES_WHERE}
+            >
+              <ServiceGrocery backend={backend} step={1} />
+            </ProtectedRoute>
+            <ProtectedRoute
+              backend={backend}
+              exact
+              path={Routes.SERVICE_GROCERIES_WHEN}
+            >
+              <ServiceGrocery backend={backend} step={2} />
+            </ProtectedRoute>
+            <ProtectedRoute
+              backend={backend}
+              exact
+              path={Routes.SERVICE_GROCERIES_WHAT}
+            >
+              <ServiceGrocery backend={backend} step={3} />
+            </ProtectedRoute>
+            <ProtectedRoute
+              backend={backend}
+              exact
+              path={Routes.SERVICE_ADDITIONAL_INFO}
+            >
+              <ServiceAdditionalInfo backend={backend} />
+            </ProtectedRoute>
             <Route exact path={Routes.FAQ}>
               <LearnMore backend={backend} />
             </Route>
+            {process.env.NODE_ENV !== 'production' && (
+              <Route exact path={Routes.STYLE_GUIDE}>
+                <StyleGuide backend={backend} />
+              </Route>
+            )}
             <Route path="*">
               <NoMatch />
             </Route>
@@ -199,9 +234,6 @@ function App({ backend }) {
             </Route>
             <Route path={Routes.PENDING_DOMAINS}>
               <PendingDomains backend={backend} />
-            </Route>
-            <Route exact path={Routes.STYLE_GUIDE}>
-              <StyleGuide backend={backend} />
             </Route>
             <Route exact path={Routes.HOME}>
               <EntryPortal backend={backend} />

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -193,7 +193,7 @@ test('Test Domain Verification', async () => {
   await backend.setDomainIsValid('kp.org', true);
 
   // This should now be empty
-  // TODO: Figure out how to test that this doesn't resolve in N amount of time
+  // service/supply TODO: Figure out how to test that this doesn't resolve in N amount of time
   //domains = new Promise((resolve, reject) => { backend.getDomains(true, resolve) })
   //expect((await domains).sort()).toStrictEqual([].sort())
   return;

--- a/src/components/AdditionalContact/AdditionalContact.js
+++ b/src/components/AdditionalContact/AdditionalContact.js
@@ -1,0 +1,45 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+import Text from 'components/Text';
+import { TEXT_TYPE } from 'components/Text/constants';
+
+import { ReactComponent as Plus } from 'static/icons/plus-circle.svg';
+
+import styles from './AdditionalContact.styles';
+
+export const AdditionalContact = ({ cta, onClick, open, title }) => (
+  <Fragment>
+    {open && (
+      <div css={styles.openContainer}>
+        <Text type={TEXT_TYPE.HEADER_4}>{title}</Text>
+      </div>
+    )}
+
+    {!open && (
+      <Text
+        onClick={(e) => {
+          e.preventDefault();
+          onClick(true);
+        }}
+        as="button"
+        type={TEXT_TYPE.BODY_2}
+        css={styles.closedButton}
+      >
+        <Plus css={styles.icon} />
+        <div>{cta}</div>
+      </Text>
+    )}
+  </Fragment>
+);
+
+AdditionalContact.propTypes = {
+  cta: PropTypes.string,
+  onClick: PropTypes.func,
+  open: PropTypes.bool,
+  title: PropTypes.string,
+};
+
+export default AdditionalContact;

--- a/src/components/AdditionalContact/AdditionalContact.styles.js
+++ b/src/components/AdditionalContact/AdditionalContact.styles.js
@@ -1,0 +1,29 @@
+import { css } from '@emotion/core';
+import { textStyles } from 'components/Text/Text.styles';
+import { Borders, buttonReset, Color, Space } from 'lib/theme';
+
+const styles = {
+  closedButton: css([
+    buttonReset,
+    textStyles.BOLD,
+    { color: Color.PRIMARY, display: 'flex', textAlign: 'left' },
+  ]),
+  icon: css({
+    flexShrink: 0,
+    marginRight: Space.S5,
+    marginTop: '2px',
+    '& circle': {
+      stroke: Color.PRIMARY,
+    },
+    '& path': {
+      fill: Color.PRIMARY,
+    },
+  }),
+  openContainer: css({
+    borderTop: Borders.GRAY1,
+    padding: `${Space.S30}px 0`,
+    width: '100%',
+  }),
+};
+
+export default styles;

--- a/src/components/AdditionalContact/index.js
+++ b/src/components/AdditionalContact/index.js
@@ -1,0 +1,1 @@
+export * from './AdditionalContact';

--- a/src/components/Checkbox/Checkbox.styles.js
+++ b/src/components/Checkbox/Checkbox.styles.js
@@ -13,6 +13,7 @@ const styles = {
     cursor: 'pointer',
     display: 'flex',
     userSelect: 'none',
+    width: '100%',
   }),
   input: css({
     display: 'none',

--- a/src/components/Form/CreateFormFields.js
+++ b/src/components/Form/CreateFormFields.js
@@ -3,13 +3,15 @@ import PropTypes from 'prop-types';
 
 import HeaderInfo from 'components/Form/HeaderInfo';
 import InputCheckbox from 'components/Checkbox';
-import InputText from 'components/InputText';
+import InputDate from 'components/InputDate';
 import InputDropdown from 'components/InputDropdown';
+import InputText from 'components/InputText';
 import TextArea from 'components/TextArea';
 
 export const formFieldTypes = {
   HEADER_INFO: 'HEADER_INFO',
   INPUT_CHECKBOX: 'INPUT_CHECKBOX',
+  INPUT_DATE: 'INPUT_DATE',
   INPUT_DROPDOWN: 'INPUT_DROPDOWN',
   INPUT_TEXT: 'INPUT_TEXT',
   NODE: 'NODE',
@@ -26,12 +28,17 @@ export const formFieldPropTypes = {
   placeholder: PropTypes.string,
   type: PropTypes.oneOf(Object.values(formFieldTypes)).isRequired,
   validation: PropTypes.object,
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.instanceOf(Date),
+  ]),
 };
 
 const inputMap = {
   [formFieldTypes.HEADER_INFO]: HeaderInfo,
   [formFieldTypes.INPUT_CHECKBOX]: InputCheckbox,
+  [formFieldTypes.INPUT_DATE]: InputDate,
   [formFieldTypes.INPUT_DROPDOWN]: InputDropdown,
   [formFieldTypes.INPUT_TEXT]: InputText,
   [formFieldTypes.TEXT_AREA]: TextArea,

--- a/src/components/HCPSignup.js
+++ b/src/components/HCPSignup.js
@@ -22,7 +22,7 @@ class HCPSignup extends React.Component {
     this.props.backend
       .signupWithEmail(this.state.email, this.state.dropsite)
       .catch(alert);
-    // TODO: handle exceptions
+    // supply TODO: handle exceptions
   }
 
   handleEmailChange(event) {

--- a/src/components/HCPSignupFinish.js
+++ b/src/components/HCPSignupFinish.js
@@ -90,7 +90,7 @@ function HCPSignupFinish({ backend }) {
           console.error('error', error);
           setSubmitting(false);
           setIsLoading(false);
-          // todo: handle this error
+          // supply todo: handle this error
         });
     },
     [backend, shouldConfirmEmail, routeToNextPage],

--- a/src/components/InputDate/InputDate.js
+++ b/src/components/InputDate/InputDate.js
@@ -10,7 +10,7 @@ import { ReactComponent as Chevron } from 'static/icons/chevron.svg';
 
 import { dayPickerStyles, styles } from './InputDate.styles';
 
-function InputDate({ label }) {
+function InputDate({ label, customOnChange }) {
   const [isFocused, setIsFocused] = useState(false);
   const [initialValue] = useState(new Date());
   const [value, setValue] = useState(initialValue);
@@ -20,13 +20,20 @@ function InputDate({ label }) {
     setIsFocused((value) => !value);
   }, []);
 
-  const handleDayChange = useCallback((selectedDay) => {
-    if (!selectedDay) {
-      setValue('');
-      return;
-    }
-    setValue(selectedDay);
-  }, []);
+  const handleDayChange = useCallback(
+    (selectedDay) => {
+      if (customOnChange) {
+        customOnChange(selectedDay);
+      }
+
+      if (!selectedDay) {
+        setValue('');
+        return;
+      }
+      setValue(selectedDay);
+    },
+    [customOnChange],
+  );
 
   return (
     <label css={[styles.container, isFocused && styles.active]}>

--- a/src/components/InputDate/InputDate.styles.js
+++ b/src/components/InputDate/InputDate.styles.js
@@ -203,6 +203,7 @@ const styles = {
     display: 'block',
     height: Height.INPUT,
     position: 'relative',
+    width: '100%',
   }),
   label: css({
     color: Color.GRAY_50,

--- a/src/components/InputDropdown/index.js
+++ b/src/components/InputDropdown/index.js
@@ -45,7 +45,6 @@ function InputDropdown({
         css={[styles.select, value === DEFAULT && styles.selectDefaultState]}
         onChange={handleChange}
         name={name}
-        defaultValue={DEFAULT}
         ref={methods?.register({ ...(isRequired && { required }) })}
         {...inputProps}
       >

--- a/src/components/Loader/PageLoader.js
+++ b/src/components/Loader/PageLoader.js
@@ -6,7 +6,7 @@ import styles from './PageLoader.styles';
 export const PageLoader = ({ passedStyles }) => {
   return (
     <span css={[styles.root, passedStyles]}>
-      Page is loading... TODO: add a page loader
+      Page is loading... service TODO: add a page loader
     </span>
   );
 };

--- a/src/components/SignupFinish.js
+++ b/src/components/SignupFinish.js
@@ -50,7 +50,7 @@ function SignupFinish({ backend }) {
           console.error('error', error);
           setSubmitting(false);
           setIsLoading(false);
-          // todo: handle this error
+          // service todo: handle this error
         });
     },
     [backend, routeToNextPage, shouldConfirmEmail],

--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -30,4 +30,8 @@ export const Routes = {
   CONTACT_FORM: `/contact`,
   CONTACT_CONFIRMATION: `/contact/confirm`,
   SERVICE_TYPE: '/service',
+  SERVICE_GROCERIES_WHERE: '/service/grocery/location',
+  SERVICE_GROCERIES_WHEN: '/service/grocery/date',
+  SERVICE_GROCERIES_WHAT: '/service/grocery/items',
+  SERVICE_ADDITIONAL_INFO: '/service/additionalinfo',
 };

--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -23,9 +23,10 @@ export const Routes = {
   SUPPLY_NEW_ADMIN_CONFIRMATION: `/new/admin/supply/:id/confirmation/:requestId`,
 
   // MVP Routes
-  EMAIL_FORM: `/signin`,
-  EMAIL_SENT: `/signin/confirm`,
-  EMAIL_APPROVE: `/signin/complete`,
+  FACILITY: `/facility`,
+  EMAIL_SIGNUP_FORM: `/signup`,
+  EMAIL_SIGNUP_SENT: `/signup/confirm`,
+  EMAIL_SIGNUP_COMPLETE: `/signup/complete`,
   CONTACT_FORM: `/contact`,
   CONTACT_CONFIRMATION: `/contact/confirm`,
   SERVICE_TYPE: '/service',

--- a/src/containers/AdditionalInfoForm.js
+++ b/src/containers/AdditionalInfoForm.js
@@ -1,0 +1,61 @@
+/** @jsx jsx */
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { jsx } from '@emotion/core';
+import { useHistory } from 'react-router-dom';
+
+import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
+
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
+
+function AdditionalInfoForm() {
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [fields, setFields] = useState({
+    additionalInfo: '',
+  });
+
+  const handleFieldChange = useCallback(
+    (field) => (value) => {
+      setFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+    console.log('go to review/submit', fields);
+    history.push(routeWithParams(Routes.SERVICE_ADDITIONAL_INFO));
+  };
+
+  const fieldData = [
+    {
+      customOnChange: handleFieldChange('additionalInfo'),
+      label: t('service.additionalInfo.labels.additionalInfo'),
+      name: 'additionalInfo',
+      type: formFieldTypes.TEXT_AREA,
+      value: fields.additionalInfo,
+    },
+  ];
+
+  return (
+    <FormBuilder
+      defaultValues={fields}
+      onSubmit={handleSubmit}
+      title={t('service.additionalInfo.title')}
+      description={t('service.additionalInfo.description')}
+      disabled={!Object.keys(fields).every((key) => !!fields[key])}
+      fields={fieldData}
+      isLoading={isLoading}
+    />
+  );
+}
+
+export default AdditionalInfoForm;

--- a/src/containers/ContactForm.js
+++ b/src/containers/ContactForm.js
@@ -42,7 +42,7 @@ function ContactForm({ backend, dropSite }) {
         console.error('error', error);
         setIsLoading(false);
       });
-    // TODO: handle exceptions
+    // supply TODO: handle exceptions
   };
 
   const fieldData = [

--- a/src/containers/EmailForm.js
+++ b/src/containers/EmailForm.js
@@ -34,13 +34,13 @@ function EmailForm({ backend }) {
     backend
       .signupServicesWithEmail(email)
       .then(() => {
-        history.push(routeWithParams(Routes.EMAIL_SENT));
+        history.push(routeWithParams(Routes.EMAIL_SIGNUP_SENT));
       })
       .catch((error) => {
         console.error('error', error);
         setIsLoading(false);
       });
-    // TODO: handle exceptions
+    // service TODO: handle exceptions
   };
 
   const fieldData = [

--- a/src/containers/GroceryFormDate.js
+++ b/src/containers/GroceryFormDate.js
@@ -1,0 +1,92 @@
+/** @jsx jsx */
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { jsx } from '@emotion/core';
+import { useHistory } from 'react-router-dom';
+
+import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
+
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
+import Note from 'components/Note';
+
+function GroceryFormDate() {
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [fields, setFields] = useState({
+    date: '',
+    time: '',
+    recurring: '',
+  });
+
+  const handleFieldChange = useCallback(
+    (field) => (value) => {
+      setFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+    // service todo: wire-up form events
+    history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHAT));
+  };
+
+  const fieldData = [
+    {
+      customOnChange: handleFieldChange('date'),
+      label: t('service.grocery.when.labels.day'),
+      name: 'date',
+      type: formFieldTypes.INPUT_DATE,
+      value: fields.date,
+    },
+    {
+      customOnChange: handleFieldChange('time'),
+      label: t('service.grocery.when.labels.time'),
+      options: [
+        { label: 'Morning', value: 'morning' },
+        { label: 'Afternoon', value: 'afternoon' },
+        { label: 'Evening', value: 'evening' },
+        { label: 'Night', value: 'night' },
+      ],
+      name: 'time',
+      type: formFieldTypes.INPUT_DROPDOWN,
+      value: fields.time,
+    },
+    {
+      customOnChange: handleFieldChange('recurring'),
+      label: t('service.grocery.when.labels.recurring'),
+      name: 'recurring',
+      type: formFieldTypes.INPUT_CHECKBOX,
+      value: fields.recurring,
+    },
+    {
+      type: formFieldTypes.NODE,
+      node: [
+        <Note key="note-2" css={{ width: '100%' }}>
+          {t('service.grocery.when.note')}
+        </Note>,
+      ],
+    },
+  ];
+
+  return (
+    <FormBuilder
+      defaultValues={fields}
+      onSubmit={handleSubmit}
+      title={t('service.grocery.when.title')}
+      description={t('service.grocery.when.description')}
+      disabled={!Object.keys(fields).every((key) => !!fields[key])}
+      fields={fieldData}
+      isLoading={isLoading}
+    />
+  );
+}
+
+export default GroceryFormDate;

--- a/src/containers/GroceryFormItems.js
+++ b/src/containers/GroceryFormItems.js
@@ -1,0 +1,68 @@
+/** @jsx jsx */
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { jsx } from '@emotion/core';
+import { useHistory } from 'react-router-dom';
+
+import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
+
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
+
+function GroceryFormItems() {
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [fields, setFields] = useState({
+    dietaryRestrictions: '',
+    groceryList: '',
+  });
+
+  const handleFieldChange = useCallback(
+    (field) => (value) => {
+      setFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+    history.push(routeWithParams(Routes.SERVICE_ADDITIONAL_INFO));
+  };
+
+  const fieldData = [
+    {
+      customOnChange: handleFieldChange('groceryList'),
+      label: t('service.grocery.what.labels.groceryList'),
+      name: 'groceryList',
+      type: formFieldTypes.TEXT_AREA,
+      value: fields.groceryList,
+    },
+    {
+      customOnChange: handleFieldChange('dietaryRestrictions'),
+      label: t('service.grocery.what.labels.dietaryRestrictions'),
+      name: 'dietaryRestrictions',
+      type: formFieldTypes.INPUT_TEXT,
+      value: fields.dietaryRestrictions,
+    },
+  ];
+
+  return (
+    <FormBuilder
+      defaultValues={fields}
+      onSubmit={handleSubmit}
+      title={t('service.grocery.what.title')}
+      description={t('service.grocery.what.description')}
+      disabled={!Object.keys(fields).every((key) => !!fields[key])}
+      fields={fieldData}
+      isLoading={isLoading}
+    />
+  );
+}
+
+export default GroceryFormItems;

--- a/src/containers/GroceryFormLocation.js
+++ b/src/containers/GroceryFormLocation.js
@@ -1,0 +1,176 @@
+/** @jsx jsx */
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { jsx } from '@emotion/core';
+import { useHistory } from 'react-router-dom';
+
+import { Routes } from 'constants/Routes';
+import { routeWithParams } from 'lib/utils/routes';
+import { isValidPhoneNumber, isValidEmail } from 'lib/utils/validations';
+
+import { AdditionalContact } from 'components/AdditionalContact';
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
+
+import { neighborhoods } from 'data/neighborhoods';
+
+const validate = (val) => {
+  if (!isValidPhoneNumber(val)) {
+    return 'Please enter a valid phone number';
+  }
+};
+
+const validateEmail = (val) => {
+  if (!isValidEmail(val)) {
+    return 'Please enter a valid email address';
+  }
+};
+
+// service todo: Temp values while we build backend or an enum for this part.
+const LANGUAGES = [
+  { label: 'English', value: 'english' },
+  { label: 'Spanish', value: 'spanish' },
+];
+
+function GroceryFormLocation() {
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [addAdditionalContact, setAddAdditionalContact] = useState(false);
+  const [fields, setFields] = useState({
+    zipCode: '',
+    neighborhood: '',
+    crossStreet: '',
+  });
+
+  const handleFieldChange = useCallback(
+    (field) => (value) => {
+      setFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+    // service todo: wire-up form events
+    history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHEN));
+  };
+
+  const fieldData = [
+    {
+      customOnChange: handleFieldChange('zipCode'),
+      label: t('service.grocery.where.labels.zip'),
+      name: 'zipCode',
+      type: formFieldTypes.INPUT_TEXT,
+      value: fields.zipCode,
+    },
+    {
+      customOnChange: handleFieldChange('neighborhood'),
+      label: t('service.grocery.where.labels.neighborhood'),
+      // service todo: wire-up neighborhoods data
+      options: neighborhoods.Brooklyn,
+      name: 'neighborhood',
+      type: formFieldTypes.INPUT_DROPDOWN,
+      value: fields.neighborhood,
+    },
+    {
+      customOnChange: handleFieldChange('crossStreet'),
+      label: t('service.grocery.where.labels.crossStreet'),
+      name: 'crossStreet',
+      type: formFieldTypes.INPUT_TEXT,
+      value: fields.crossStreet,
+    },
+    {
+      type: formFieldTypes.NODE,
+      node: [
+        <AdditionalContact
+          cta={t('service.grocery.where.add')}
+          key="additional"
+          onClick={setAddAdditionalContact}
+          open={addAdditionalContact}
+          title={t('service.grocery.where.additionalContact.title')}
+        />,
+      ],
+    },
+  ];
+
+  const additionalContactFields = [
+    {
+      customOnChange: handleFieldChange('firstName'),
+      label: t('service.contactForm.labels.firstName'),
+      name: 'firstName',
+      type: formFieldTypes.INPUT_TEXT,
+    },
+    {
+      customOnChange: handleFieldChange('lastName'),
+      label: t('service.grocery.where.additionalContact.labels.lastName'),
+      name: 'lastName',
+      type: formFieldTypes.INPUT_TEXT,
+    },
+    {
+      customOnChange: handleFieldChange('relationship'),
+      label: t('service.grocery.where.additionalContact.labels.relationship'),
+      options: [
+        { label: 'Partner', value: 'partner' },
+        { label: 'Family member', value: 'family-member' },
+        { label: 'Friend', value: 'friend' },
+      ],
+      name: 'relationship',
+      type: formFieldTypes.INPUT_DROPDOWN,
+    },
+    {
+      customOnChange: handleFieldChange('email'),
+      label: t('service.grocery.where.additionalContact.labels.email'),
+      name: 'email',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validateEmail },
+    },
+    {
+      customOnChange: handleFieldChange('phone'),
+      isRequired: false,
+      label: t('service.contactForm.labels.phone'),
+      name: 'phone',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate },
+    },
+    {
+      customOnChange: handleFieldChange('contactPreference'),
+      label: t('service.contactForm.labels.contactPreference'),
+      options: [
+        { label: 'Email', value: 'email' },
+        { label: 'Phone', value: 'phone' },
+      ],
+      name: 'contactPreference',
+      type: formFieldTypes.INPUT_DROPDOWN,
+    },
+    {
+      customOnChange: handleFieldChange('languagePreference'),
+      label: t('service.contactForm.labels.languagePreference'),
+      options: LANGUAGES,
+      name: 'languagePreference',
+      type: formFieldTypes.INPUT_DROPDOWN,
+    },
+  ];
+
+  return (
+    <FormBuilder
+      defaultValues={fields}
+      onSubmit={handleSubmit}
+      title={t('service.grocery.where.title')}
+      description={t('service.grocery.where.description')}
+      disabled={!Object.keys(fields).every((key) => !!fields[key])}
+      fields={
+        addAdditionalContact
+          ? [...fieldData, ...additionalContactFields]
+          : fieldData
+      }
+      isLoading={isLoading}
+    />
+  );
+}
+
+export default GroceryFormLocation;

--- a/src/containers/ServiceContactForm.js
+++ b/src/containers/ServiceContactForm.js
@@ -1,75 +1,134 @@
 /** @jsx jsx */
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { jsx } from '@emotion/core';
 import { useHistory } from 'react-router-dom';
 
 import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
-import { isValidEmail, isValidPhoneNumber } from 'lib/utils/validations';
+import { isValidPhoneNumber } from 'lib/utils/validations';
 
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
+import Note from 'components/Note';
 
 const validate = (val) => {
-  if (!isValidPhoneNumber(val) && !isValidEmail(val)) {
-    return 'Please enter a valid email address or phone number';
+  if (!isValidPhoneNumber(val)) {
+    return 'Please enter a valid phone number';
   }
 };
+
+// service todo: Temp values while we build backend or an enum for this part.
+const LANGUAGES = [
+  { label: 'English', value: 'english' },
+  { label: 'Spanish', value: 'spanish' },
+];
 
 function ServiceContactForm({ backend }) {
   const history = useHistory();
   const { t } = useTranslation();
 
-  const [name, setName] = useState('');
-  const [contact, setContact] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [fields, setFields] = useState({
+    firstName: '',
+    lastName: '',
+    phone: '',
+    contactPreference: '',
+    languagePreference: '',
+  });
 
-  const handleSubmit = () => {
+  const handleFieldChange = useCallback(
+    (field) => (value) => {
+      setFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
+  const { phone, ...requiredFields } = fields;
+
+  const handleSubmit = (data) => {
     setIsLoading(true);
     history.push(routeWithParams(Routes.CONTACT_CONFIRMATION));
 
-    // todo: wire up new action, something like editUserContact, see rough idea below
+    // service todo: wire up new action, something like editUserContact, see rough idea below
     /*
     backend
-      .editUserContact({
+      .editUser({
         //params
       })
       .then(() => {
-        history.push(routeWithParams(Routes.CONTACT_CONFIRMATION));
+        console.log('ok here');
+        setIsLoading(false);
+        // history.push(routeWithParams(Routes.CONTACT_CONFIRMATION));
       })
       .catch((error) => {
         console.error('error', error);
         setIsLoading(false);
       });
-      */
-    // TODO: handle exceptions
+     */
+    // service TODO: handle exceptions
   };
 
   const fieldData = [
     {
-      customOnChange: setName,
+      customOnChange: handleFieldChange('firstName'),
       label: t('request.dropSiteContactForm.nameLabel'),
-      name: 'name',
+      name: 'firstName',
       type: formFieldTypes.INPUT_TEXT,
     },
     {
-      customOnChange: setContact,
+      customOnChange: handleFieldChange('lastName'),
       label: t('request.dropSiteContactForm.contactLabel'),
-      name: 'contact',
+      name: 'lastName',
+      type: formFieldTypes.INPUT_TEXT,
+    },
+    {
+      customOnChange: handleFieldChange('phone'),
+      isRequired: false,
+      label: t('service.contactForm.phone.label'),
+      name: 'phone',
       type: formFieldTypes.INPUT_TEXT,
       validation: { validate },
+    },
+    {
+      customOnChange: handleFieldChange('contactPreference'),
+      label: t('service.contactForm.contactPreference.label'),
+      options: [
+        { label: 'Email', value: 'email' },
+        { label: 'Phone', value: 'phone' },
+      ],
+      name: 'contactPreference',
+      type: formFieldTypes.INPUT_DROPDOWN,
+    },
+    {
+      type: formFieldTypes.NODE,
+      node: [
+        <Note key="note-2" css={{ width: '100%' }}>
+          {t('service.contactForm.languagePreference.description')}
+        </Note>,
+      ],
+    },
+    {
+      customOnChange: handleFieldChange('languagePreference'),
+      label: t('service.contactForm.languagePreference.label'),
+      options: LANGUAGES,
+      name: 'languagePreference',
+      type: formFieldTypes.INPUT_DROPDOWN,
     },
   ];
 
   return (
     <FormBuilder
-      defaultValues={{ name, contact }}
+      defaultValues={fields}
       onSubmit={handleSubmit}
       title={t('service.contactForm.title')}
       description={t('service.contactForm.description')}
       disabled={
-        (!isValidPhoneNumber(contact) && !isValidEmail(contact)) || !name
+        !isValidPhoneNumber(fields.phone) ||
+        !Object.keys(requiredFields).every((key) => !!fields[key])
       }
       fields={fieldData}
       isLoading={isLoading}

--- a/src/containers/ServiceContactForm.js
+++ b/src/containers/ServiceContactForm.js
@@ -75,27 +75,27 @@ function ServiceContactForm({ backend }) {
   const fieldData = [
     {
       customOnChange: handleFieldChange('firstName'),
-      label: t('request.dropSiteContactForm.nameLabel'),
+      label: t('service.contactForm.labels.firstName'),
       name: 'firstName',
       type: formFieldTypes.INPUT_TEXT,
     },
     {
       customOnChange: handleFieldChange('lastName'),
-      label: t('request.dropSiteContactForm.contactLabel'),
+      label: t('service.contactForm.labels.lastName'),
       name: 'lastName',
       type: formFieldTypes.INPUT_TEXT,
     },
     {
       customOnChange: handleFieldChange('phone'),
       isRequired: false,
-      label: t('service.contactForm.phone.label'),
+      label: t('service.contactForm.labels.phone'),
       name: 'phone',
       type: formFieldTypes.INPUT_TEXT,
       validation: { validate },
     },
     {
       customOnChange: handleFieldChange('contactPreference'),
-      label: t('service.contactForm.contactPreference.label'),
+      label: t('service.contactForm.labels.contactPreference'),
       options: [
         { label: 'Email', value: 'email' },
         { label: 'Phone', value: 'phone' },
@@ -107,13 +107,13 @@ function ServiceContactForm({ backend }) {
       type: formFieldTypes.NODE,
       node: [
         <Note key="note-2" css={{ width: '100%' }}>
-          {t('service.contactForm.languagePreference.description')}
+          {t('service.contactForm.note')}
         </Note>,
       ],
     },
     {
       customOnChange: handleFieldChange('languagePreference'),
-      label: t('service.contactForm.languagePreference.label'),
+      label: t('service.contactForm.labels.languagePreference'),
       options: LANGUAGES,
       name: 'languagePreference',
       type: formFieldTypes.INPUT_DROPDOWN,

--- a/src/containers/ServiceFacilityForm.js
+++ b/src/containers/ServiceFacilityForm.js
@@ -72,7 +72,7 @@ const getHospitalName = ({ hospital, id }) => ({
   value: id,
 });
 
-function FindFacility({ backend }) {
+function ServiceFacilityForm({ backend }) {
   const history = useHistory();
   const { t } = useTranslation();
   const [results, setResults] = useState([]);
@@ -124,4 +124,4 @@ function FindFacility({ backend }) {
   );
 }
 
-export default FindFacility;
+export default ServiceFacilityForm;

--- a/src/containers/ServiceTypeForm.js
+++ b/src/containers/ServiceTypeForm.js
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router-dom';
 
 import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
+import RequestKinds from 'lib/organizations/kinds';
 
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
@@ -31,11 +32,19 @@ function ServiceTypeForm() {
   );
 
   const handleSubmit = () => {
+    const { serviceType } = fields;
     setIsLoading(true);
-    history.push(routeWithParams(Routes.SERVICE_TYPE));
-    console.log(
-      'service todo: route to specific service request form, groceries, childcare, etc.',
-    );
+
+    switch (serviceType) {
+      case RequestKinds.GROCERY:
+        history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHERE));
+        break;
+      default:
+        history.push(routeWithParams(Routes.SERVICE_TYPE));
+        console.log(
+          'service todo: route to specific service request form, groceries, childcare, etc.',
+        );
+    }
   };
 
   const fieldData = [
@@ -44,10 +53,10 @@ function ServiceTypeForm() {
       label: t('service.selectType.form.serviceTypeLabel'),
       // todo: move these values to enum
       options: [
-        { label: 'Groceries', value: 'groceries' },
-        { label: 'Childcare', value: 'childcare' },
-        { label: 'Pet care', value: 'petcare' },
-        { label: 'Emotional support', value: 'emotional-support' },
+        { label: 'Groceries', value: RequestKinds.GROCERY },
+        { label: 'Childcare', value: RequestKinds.CHILDCARE },
+        { label: 'Pet care', value: RequestKinds.PETCARE },
+        { label: 'Emotional support', value: RequestKinds.MENTALHEALTH },
       ],
       name: 'serviceType',
       type: formFieldTypes.INPUT_DROPDOWN,

--- a/src/containers/ServiceTypeForm.js
+++ b/src/containers/ServiceTypeForm.js
@@ -34,7 +34,7 @@ function ServiceTypeForm() {
     setIsLoading(true);
     history.push(routeWithParams(Routes.SERVICE_TYPE));
     console.log(
-      'todo: route to specific service request form, groceries, childcare, etc.',
+      'service todo: route to specific service request form, groceries, childcare, etc.',
     );
   };
 

--- a/src/containers/SupplyForm.js
+++ b/src/containers/SupplyForm.js
@@ -71,7 +71,7 @@ function SupplyForm({ backend }) {
       type: formFieldTypes.INPUT_DROPDOWN,
       value: requiredFields.requestType,
       options: [
-        // TODO: get real options
+        // supply TODO: get real options
         {
           value: 'Mask',
           label: 'Mask',
@@ -89,7 +89,7 @@ function SupplyForm({ backend }) {
       type: formFieldTypes.INPUT_DROPDOWN,
       value: requiredFields.requestTitle,
       options: [
-        // TODO: get real kinds
+        // supply TODO: get real kinds
         {
           value: 'Kind One',
           label: 'Kind One',

--- a/src/data/neighborhoods.js
+++ b/src/data/neighborhoods.js
@@ -1,0 +1,215 @@
+export const neighborhoods = {
+  Brooklyn: [
+    { label: 'Bath Beach', value: 'bath-beach' },
+    { label: 'Bay Ridge', value: 'bay-ridge' },
+    { label: 'Bedford-Stuyvesant', value: 'bedford-stuyvesant' },
+    { label: 'Bensonhurst', value: 'bensonhurst' },
+    { label: 'Bergen Beach', value: 'bergen-beach' },
+    { label: 'Boerum Hill', value: 'boerum-hill' },
+    { label: 'Borough Park', value: 'borough-park' },
+    { label: 'Brighton Beach', value: 'brighton-beach' },
+    { label: 'Brooklyn Heights', value: 'brooklyn-heights' },
+    { label: 'Brownsville', value: 'brownsville' },
+    { label: 'Bushwick', value: 'bushwick' },
+    { label: 'Canarsie', value: 'canarsie' },
+    { label: 'Carroll Gardens', value: 'carroll-gardens' },
+    { label: 'Cobble Hill', value: 'cobble-hill' },
+    { label: 'Coney Island', value: 'coney-island' },
+    { label: 'Crown Heights', value: 'crown-heights' },
+    { label: 'Cypress Hills', value: 'cypress-hills' },
+    { label: 'Downtown Brooklyn', value: 'downtown-brooklyn' },
+    { label: 'Dumbo/Vinegar Hill', value: 'dumbo-vinegar-hill' },
+    { label: 'Dyker Heights', value: 'dyker-heights' },
+    { label: 'East New York', value: 'east-new-york' },
+    { label: 'Flatbush', value: 'flatbush' },
+    { label: 'Flatlands', value: 'flatlands' },
+    { label: 'Fort Greene/Clinton Hill', value: 'fort-greene-clinton-hill' },
+    { label: 'Gerritsen Beach', value: 'gerritsen-beach' },
+    { label: 'Gowanus', value: 'gowanus' },
+    { label: 'Gravesend', value: 'gravesend' },
+    { label: 'Greenpoint', value: 'greenpoint' },
+    { label: 'Greenwood Heights', value: 'greenwood-heights' },
+    { label: 'Manhattan Beach', value: 'manhattan-beach' },
+    { label: 'Marine Park', value: 'marine-park' },
+    { label: 'Midwood', value: 'midwood' },
+    { label: 'Mill Basin', value: 'mill-basin' },
+    { label: 'Park Slope', value: 'park-slope' },
+    { label: 'Prospect Heights', value: 'prospect-heights' },
+    {
+      label: 'Prospect Park South/Kensington',
+      value: 'prospect-park-south-kensington',
+    },
+    { label: 'Red Hook', value: 'red-hook' },
+    { label: 'Sea Gate', value: 'sea-gate' },
+    { label: 'Sheepshead Bay', value: 'sheepshead-bay' },
+    { label: 'Sunset Park', value: 'sunset-park' },
+    { label: 'Williamsburg', value: 'williamsburg' },
+    { label: 'Windsor Terrace', value: 'windsor-terrace' },
+  ],
+};
+
+/*
+Manhattan
+Alphabet City
+Battery Park City
+Carnegie Hill
+Chelsea
+Chinatown
+East Harlem
+East Village
+Financial District
+Flatiron District
+Gramercy Park
+Greenwich Village
+Harlem
+Hell's Kitchen/Clinton
+Inwood
+Kips Bay
+Lincoln Square
+Lower East Side
+Manhattan Valley
+Midtown East
+Midtown West
+Morningside Heights
+Murray Hill
+NoLita/Little Italy
+Roosevelt Island
+SoHo
+Tribeca
+Upper East Side
+Upper West Side
+Washington Heights
+West Village
+
+Queens
+Arverne
+Astoria
+Bayside
+Beechhurst
+Belle Harbor/Neponsit
+Bellerose
+Briarwood
+Broad Channel
+Cambria Heights
+College Point
+Corona
+Douglaston
+East Elmhurst
+Elmhurst
+Far Rockaway
+Floral Park
+Flushing
+Forest Hills
+Fresh Meadows
+Glen Oaks
+Glendale
+Hillcrest
+Hollis
+Hollis Hills
+Howard Beach
+Jackson Heights
+Jamaica
+Jamaica Estates
+Jamaica Hills
+Kew Gardens
+Laurelton
+Little Neck
+Long Island City
+Maspeth
+Middle Village
+Oakland Gardens
+Ozone Park
+Queens Village
+Rego Park
+Richmond Hill
+Ridgewood
+Rockaway Park
+Rosedale
+South Jamaica
+South Ozone Park
+Springfield Gardens
+St. Albans
+Sunnyside
+Whitestone
+Woodhaven
+Woodside
+
+Bronx
+Baychester/Co-op City
+Bedford Park
+Belmont
+Bronxdale
+Castle Hill
+City Island
+Concourse Village/Grand Concourse/Morrisania
+Country Club
+Fieldston
+Fordham
+Hunts Point
+Kingsbridge
+Kingsbridge Heights
+Melrose
+Morris Heights
+Morris Park
+Mott Haven
+Parkchester
+Pelham Bay
+Pelham Gardens
+Pelham Parkway
+Port Morris
+Riverdale
+Soundview
+Throgs Neck
+Tremont
+University Heights
+Wakefield
+Williamsbridge
+Woodlawn
+
+Staten Island
+Annadale
+Arden Heights
+Arrochar
+Bay Street
+Bulls Head
+Castleton Corners
+Charleston
+Clifton
+Dongan Hills
+Eltingville
+Emerson Hill
+Graniteville
+Grant City
+Grasmere/Concord
+Great Kills
+Grymes Hill
+Huguenot
+Livingston
+Manor Heights
+Mariners Harbor
+Midland Beach
+New Brighton
+New Dorp/New Dorp Beach
+New Springville
+Oakwood
+Pleasant Plains
+Port Richmond
+Prince's Bay
+Richmondtown
+Rosebank
+Rossville
+Shore Acres
+Silver Lake
+South Beach
+St. George
+Stapleton
+Sunnyside
+Todt Hill
+Tompkinsville
+Tottenville
+Travis
+West New Brighton
+Westerleigh
+Willowbrook
+Woodrow
+*/

--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -570,7 +570,7 @@ export default class FirebaseBackend {
 
   async signupServicesWithEmail(email) {
     const actionCodeSettings = {
-      url: `${window.location.protocol}//${window.location.host}${Routes.EMAIL_APPROVE}/`,
+      url: `${window.location.protocol}//${window.location.host}${Routes.EMAIL_SIGNUP_COMPLETE}/`,
       handleCodeInApp: true,
     };
 

--- a/src/lib/organizations/dummy.js
+++ b/src/lib/organizations/dummy.js
@@ -1,0 +1,44 @@
+const RequestKinds = require('./kinds');
+
+const DummyMetadata = {
+  id: 'testOrg',
+  Organization: 'test org NYC',
+  Kind: RequestKinds.GROCERY,
+  ZipCodes: [11238, 11222],
+  Fields: [
+    {
+      id: 'first_name',
+      label: 'First Name',
+    },
+    {
+      id: 'last_name',
+      label: 'Phone',
+    },
+    {
+      id: 'email',
+      label: 'Email',
+    },
+    {
+      id: 'urgency',
+      label: 'How soon do you need support?',
+      choices: [
+        {
+          name: 'Immediately',
+          value: 1,
+        },
+        {
+          name: 'In the next few days',
+          value: 2,
+        },
+        {
+          name: 'Sometime soon',
+          value: 3,
+        },
+      ],
+    },
+  ],
+  DeliverRequest: (backend, request) => {},
+  HandleUpdate: (row) => {},
+};
+
+export default DummyMetadata;

--- a/src/lib/organizations/index.js
+++ b/src/lib/organizations/index.js
@@ -1,5 +1,5 @@
 import MANYCMetadata from './manyc';
-import DummyMetadata from './dummy';
+// import DummyMetadata from './dummy';
 
 var OrganizationIndex = {
   ByZip: {},
@@ -18,6 +18,6 @@ function RegisterOrganization(metadata) {
 
 // We should compute this statically beforehand
 RegisterOrganization(MANYCMetadata);
-RegisterOrganization(DummyMetadata);
+// RegisterOrganization(DummyMetadata);
 
 export default OrganizationIndex;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -179,15 +179,21 @@
       "contactForm": {
         "title": "Contact info",
         "description": "Enter your contact information so we can coordinate the services you request.",
-        "nameLabel": "Name",
-        "contactLabel": "Email or phone number",
+        "labels": {
+          "firstName": "First name",
+          "languagePreference": "Preferred language",
+          "lastName": "Last name",
+          "phone": "Phone number",
+          "contactPreference": "Preferred contact method"
+        },
+        "note": "Tell us if you are more comfortable with a non-English language and we'll try to find someone who speaks your language.",
         "sent": {
           "title": "We added the facility contact info",
           "buttonLabel": "Create new request"
         }
       },
       "contactConfirm": {
-        "title": "We added your contact info"
+        "title": "Thank you for providing your contact info"
       },
       "selectType": {
         "title": "What type of service are you looking for?",
@@ -195,6 +201,51 @@
         "form": {
           "serviceTypeLabel": "Service type",
           "urgencyLabel": "Urgency"
+        }
+      },
+      "additionalInfo": {
+        "title": "Is there anything else we should know?",
+        "description": "Tell us any additional information that might be helpful to the volunteer fulfilling your request.",
+        "labels": {
+          "additionalInfo": "Additional info (optional)"
+        }
+      },
+      "grocery": {
+        "where": {
+          "title": "Where do you want groceries delivered?",
+          "description": "This allows us to connect you with support close to home. The volunteer providing the service will reach out to get your exact address. Our childcare partner, Workers Need Childcare, only uses licensed childcare",
+          "add": "Add an additional contact person for this request",
+          "labels": {
+            "zip": "ZIP code",
+            "neighborhood": "Neighborhood",
+            "crossStreet": "Cross Street"
+          },
+          "additionalContact": {
+            "title": "Additional contact info",
+            "labels": {
+              "email": "Email address (optional)",
+              "lastName": "Last name (optional)",
+              "relationship": "Relationship (optional)"
+            }
+          }
+        },
+        "when": {
+          "title": "When do you want groceries delivered?",
+          "description": "Select the day and time you prefer to receive your groceries.",
+          "labels": {
+            "day": "Day",
+            "recurring": "This is a recurring need",
+            "time": "Time"
+          },
+          "note": "Please bear in mind that many people need help and we cannot guarantee a quick response to your request."
+        },
+        "what": {
+          "title": "What groceries do you need?",
+          "description": "The more specific your request, the more likely you will receive what you need.",
+          "labels": {
+            "groceryList": "Grocery list (e.g., 6 bananas, 1 loaf whole wheat bread, 2 avocados)",
+            "dietaryRestrictions": "Dietary restrictions"
+          }
         }
       }
     }

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -16,7 +16,7 @@ function Contact({ backend }) {
   return (
     <Page
       onBackButtonClick={() =>
-        // todo: if user has contact info set, route to userDetail page
+        // service todo: if user has contact info set, route to userDetail page
         history.push(routeWithParams(Routes.HOME))
       }
       currentProgress={2}

--- a/src/pages/contact_confirmation.js
+++ b/src/pages/contact_confirmation.js
@@ -10,7 +10,7 @@ import Page from 'components/layouts/Page';
 import PageLoader from 'components/Loader/PageLoader';
 import { ContactConfirmation } from 'components/Confirmation';
 
-// todo: Temp values while we build backend for this part.
+// service todo: Temp values while we build backend for this part.
 const TEMP_NAME = 'Temp User';
 const TEMP_CONTACT = 'medicalWorker@healthcarefacility.com';
 

--- a/src/pages/entry.js
+++ b/src/pages/entry.js
@@ -32,7 +32,7 @@ function EntryPortal() {
       rootContainerStyles={containerStyles}
     >
       <ListLink
-        href={Routes.EMAIL_FORM}
+        href={Routes.FACILITY}
         title={t('home.needServices.title')}
         text={t('home.needServices.description')}
       />

--- a/src/pages/facility.js
+++ b/src/pages/facility.js
@@ -1,0 +1,15 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+
+import Page from 'components/layouts/Page';
+import FacilityForm from 'containers/FacilityForm';
+
+function Facility(props) {
+  return (
+    <Page currentProgress={1} totalProgress={5}>
+      <FacilityForm {...props} />
+    </Page>
+  );
+}
+
+export default Facility;

--- a/src/pages/service_additional_info.js
+++ b/src/pages/service_additional_info.js
@@ -1,0 +1,15 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+
+import Page from 'components/layouts/Page';
+import AdditionalInfoForm from 'containers/AdditionalInfoForm';
+
+function ServiceAdditionalInfo({ backend }) {
+  return (
+    <Page currentProgress={4} totalProgress={5}>
+      <AdditionalInfoForm backend={backend} />
+    </Page>
+  );
+}
+
+export default ServiceAdditionalInfo;

--- a/src/pages/service_grocery.js
+++ b/src/pages/service_grocery.js
@@ -1,0 +1,19 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+
+import Page from 'components/layouts/Page';
+import GroceryFormLocation from 'containers/GroceryFormLocation';
+import GroceryFormDate from 'containers/GroceryFormDate';
+import GroceryFormItems from 'containers/GroceryFormItems';
+
+function ServiceGrocery({ step }) {
+  return (
+    <Page currentProgress={4} totalProgress={5}>
+      {step === 1 && <GroceryFormLocation />}
+      {step === 2 && <GroceryFormDate />}
+      {step === 3 && <GroceryFormItems />}
+    </Page>
+  );
+}
+
+export default ServiceGrocery;


### PR DESCRIPTION
Updating existing pages to the latest flow indicated in figma:
https://www.figma.com/file/agqX5S9NoMPEzBu1cLQ4ob/Help-Supply---Services?node-id=455%3A5222

* All backend calls (mostly via submit handling) are marked with `todo:`
  * Went through all of the 'todos' and marked whether it was related to service, supply, or both.
* ~Moved the Email form to a simple `/email` route since it is no longer being used for a signup/signin process.~
* Moved 'email' routes to be more explicitly used for signing up, in preparation for new 'sign in' flow.
* Removed `defaultValue` on InputDropdown since it is ignored and `react-hook-form` handles this value.