### PR TITLE
Save grocery service as user navigates form

### DIFF
--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -30,8 +30,8 @@ export const Routes = {
   CONTACT_FORM: `/contact`,
   CONTACT_CONFIRMATION: `/contact/confirm`,
   SERVICE_TYPE: '/service',
-  SERVICE_GROCERIES_WHERE: '/service/grocery/location',
-  SERVICE_GROCERIES_WHEN: '/service/grocery/date',
-  SERVICE_GROCERIES_WHAT: '/service/grocery/items',
-  SERVICE_ADDITIONAL_INFO: '/service/additionalinfo',
+  SERVICE_GROCERIES_WHERE: '/service/grocery/location/:id',
+  SERVICE_GROCERIES_WHEN: '/service/grocery/date/:id',
+  SERVICE_GROCERIES_WHAT: '/service/grocery/items/:id',
+  SERVICE_ADDITIONAL_INFO: '/service/additionalinfo/:id',
 };

--- a/src/containers/AdditionalInfoForm.js
+++ b/src/containers/AdditionalInfoForm.js
@@ -2,7 +2,7 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { jsx } from '@emotion/core';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
 
 import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
@@ -10,8 +10,9 @@ import { routeWithParams } from 'lib/utils/routes';
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
-function AdditionalInfoForm() {
+function AdditionalInfoForm({ backend }) {
   const history = useHistory();
+  const params = useParams();
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
@@ -29,10 +30,13 @@ function AdditionalInfoForm() {
     [],
   );
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     setIsLoading(true);
+    await backend.updateServiceRequest(params.id, fields, true);
     console.log('go to review/submit', fields);
-    history.push(routeWithParams(Routes.SERVICE_ADDITIONAL_INFO));
+    history.push(
+      routeWithParams(Routes.SERVICE_ADDITIONAL_INFO, { id: params.id }),
+    );
   };
 
   const fieldData = [

--- a/src/containers/GroceryFormDate.js
+++ b/src/containers/GroceryFormDate.js
@@ -11,7 +11,7 @@ import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 import Note from 'components/Note';
 
-function GroceryFormDate() {
+function GroceryFormDate({ id, onSave }) {
   const history = useHistory();
   const { t } = useTranslation();
 
@@ -32,10 +32,10 @@ function GroceryFormDate() {
     [],
   );
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     setIsLoading(true);
-    // service todo: wire-up form events
-    history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHAT));
+    await onSave(fields);
+    history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHAT, { id }));
   };
 
   const fieldData = [

--- a/src/containers/GroceryFormItems.js
+++ b/src/containers/GroceryFormItems.js
@@ -10,7 +10,7 @@ import { routeWithParams } from 'lib/utils/routes';
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
-function GroceryFormItems() {
+function GroceryFormItems({ id, onSave }) {
   const history = useHistory();
   const { t } = useTranslation();
 
@@ -30,9 +30,10 @@ function GroceryFormItems() {
     [],
   );
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     setIsLoading(true);
-    history.push(routeWithParams(Routes.SERVICE_ADDITIONAL_INFO));
+    await onSave(fields);
+    history.push(routeWithParams(Routes.SERVICE_ADDITIONAL_INFO, { id }));
   };
 
   const fieldData = [

--- a/src/containers/GroceryFormLocation.js
+++ b/src/containers/GroceryFormLocation.js
@@ -32,7 +32,7 @@ const LANGUAGES = [
   { label: 'Spanish', value: 'spanish' },
 ];
 
-function GroceryFormLocation() {
+function GroceryFormLocation({ id, onSave }) {
   const history = useHistory();
   const { t } = useTranslation();
 
@@ -54,10 +54,10 @@ function GroceryFormLocation() {
     [],
   );
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     setIsLoading(true);
-    // service todo: wire-up form events
-    history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHEN));
+    await onSave(fields);
+    history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHEN, { id }));
   };
 
   const fieldData = [

--- a/src/containers/ServiceTypeForm.js
+++ b/src/containers/ServiceTypeForm.js
@@ -11,13 +11,13 @@ import RequestKinds from 'lib/organizations/kinds';
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
-function ServiceTypeForm() {
+function ServiceTypeForm({ backend }) {
   const history = useHistory();
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState({
-    serviceType: '',
+    kind: '',
     urgency: '',
   });
 
@@ -31,13 +31,20 @@ function ServiceTypeForm() {
     [],
   );
 
-  const handleSubmit = () => {
-    const { serviceType } = fields;
+  const handleSubmit = async () => {
+    const { kind } = fields;
     setIsLoading(true);
-
-    switch (serviceType) {
+    const serviceRequestId = await backend.saveServiceRequest(fields);
+    if (!serviceRequestId) {
+      return;
+    }
+    switch (kind) {
       case RequestKinds.GROCERY:
-        history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHERE));
+        history.push(
+          routeWithParams(Routes.SERVICE_GROCERIES_WHERE, {
+            id: serviceRequestId,
+          }),
+        );
         break;
       default:
         history.push(routeWithParams(Routes.SERVICE_TYPE));
@@ -49,7 +56,7 @@ function ServiceTypeForm() {
 
   const fieldData = [
     {
-      customOnChange: handleFieldChange('serviceType'),
+      customOnChange: handleFieldChange('kind'),
       label: t('service.selectType.form.serviceTypeLabel'),
       // todo: move these values to enum
       options: [
@@ -58,9 +65,9 @@ function ServiceTypeForm() {
         { label: 'Pet care', value: RequestKinds.PETCARE },
         { label: 'Emotional support', value: RequestKinds.MENTALHEALTH },
       ],
-      name: 'serviceType',
+      name: 'kind',
       type: formFieldTypes.INPUT_DROPDOWN,
-      value: fields.serviceType,
+      value: fields.kind,
     },
     {
       customOnChange: handleFieldChange('urgency'),

--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -45,7 +45,9 @@ export default class FirebaseBackend {
       throw new Error("Request needs a 'kind'");
     }
     if (request.organization === undefined) {
-      throw new Error("Request needs a mapped 'organization'");
+      // TODO: map a request to an organization
+      request.organization = 'placeholder';
+      // throw new Error("Request needs a mapped 'organization'");
     }
     if (request.user !== undefined) {
       throw new Error("'user' is a reserved property for Requests");
@@ -63,7 +65,6 @@ export default class FirebaseBackend {
     const { currentUser } = this.firebase.auth();
     request.domain = currentUser ? currentUser.email.split('@')[1] || '' : '';
     request.user = currentUser ? currentUser.uid || '' : '';
-
     return (await this.firestore.collection('servicerequest').add(request)).id;
   }
 

--- a/src/pages/service_grocery.js
+++ b/src/pages/service_grocery.js
@@ -5,13 +5,21 @@ import Page from 'components/layouts/Page';
 import GroceryFormLocation from 'containers/GroceryFormLocation';
 import GroceryFormDate from 'containers/GroceryFormDate';
 import GroceryFormItems from 'containers/GroceryFormItems';
+import { useParams } from 'react-router-dom';
 
-function ServiceGrocery({ step }) {
+function ServiceGrocery({ backend, step }) {
+  const params = useParams();
+
+  const updateService = (request) => {
+    backend.updateServiceRequest(params.id, request, true);
+  };
   return (
     <Page currentProgress={4} totalProgress={5}>
-      {step === 1 && <GroceryFormLocation />}
-      {step === 2 && <GroceryFormDate />}
-      {step === 3 && <GroceryFormItems />}
+      {step === 1 && (
+        <GroceryFormLocation onSave={updateService} id={params.id} />
+      )}
+      {step === 2 && <GroceryFormDate onSave={updateService} id={params.id} />}
+      {step === 3 && <GroceryFormItems onSave={updateService} id={params.id} />}
     </Page>
   );
 }


### PR DESCRIPTION
Similarly to the old create dropsite flow, we create a blank service request when a user begins the service form flow, starting with `kind` and `urgency`. From there we update the service through the grocery form (location, date, items, notes) and will eventually send the user to the "review request" page.

This also adds an id param to the additional info page so we can look a service up and update from there.

Seems a little repetitious to have a review then submit request page since we are actually saving it behind the scenes but because everything lives on a separate page this is the easiest option for the time being.

It's still not clear to me how we determine which fulfillment organization should be assigned as we create a request so in the meantime i've added a placeholder string.

Also the third argument (admin) is set to true when updating because we validate a user before they can reach these pages, so in theory they should always be an admin. let me know if that doesn't make sense.


edit: looks like tests are failing on master