### PR TITLE
Validation tweaks

### DIFF
--- a/src/components/Form/CreateFormFields.js
+++ b/src/components/Form/CreateFormFields.js
@@ -20,6 +20,11 @@ export const formFieldTypes = {
 
 export const formFieldPropTypes = {
   customOnChange: PropTypes.func,
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.bool,
+    PropTypes.instanceOf(Date),
+  ]),
   isHalfWidth: PropTypes.bool,
   isRequired: PropTypes.bool,
   label: PropTypes.string,

--- a/src/components/InputDate/InputDate.js
+++ b/src/components/InputDate/InputDate.js
@@ -10,9 +10,9 @@ import { ReactComponent as Chevron } from 'static/icons/chevron.svg';
 
 import { dayPickerStyles, styles } from './InputDate.styles';
 
-function InputDate({ label, customOnChange }) {
+function InputDate({ label, customOnChange, defaultValue }) {
   const [isFocused, setIsFocused] = useState(false);
-  const [initialValue] = useState(new Date());
+  const [initialValue] = useState(defaultValue ? defaultValue : new Date());
   const [value, setValue] = useState(initialValue);
   const dayPicker = useRef(null);
 

--- a/src/components/InputText/index.js
+++ b/src/components/InputText/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { useCallback, useState } from 'react';
 import { TEXT_TYPE } from 'components/Text/constants';
 import Text from 'components/Text';
-import { useFormContext } from 'react-hook-form';
+import { Controller, useFormContext } from 'react-hook-form';
 import { required } from 'lib/utils/validations';
 
 import styles from './InputText.styles';
@@ -29,6 +29,7 @@ function InputText({
         customOnChange(event.target.value);
       }
       setValue(event.target.value);
+      return event.target.value;
     },
     [customOnChange],
   );
@@ -45,16 +46,17 @@ function InputText({
             {label}
           </div>
         )}
-        <input
-          ref={methods?.register({
-            ...validation,
-            ...(isRequired && { required }),
-          })}
-          css={styles.input}
+        <Controller
+          as={<input css={styles.input} />}
+          defaultValue={defaultValue}
+          name={name}
           onBlur={toggleFocus}
           onFocus={toggleFocus}
-          onChange={onChange}
-          name={name}
+          onChange={(args) => onChange(args[0].nativeEvent)}
+          rules={{
+            ...validation,
+            ...(isRequired && { required }),
+          }}
         />
       </label>
       <Text as="p" type={TEXT_TYPE.NOTE} css={styles.error}>

--- a/src/containers/AdditionalInfoForm.js
+++ b/src/containers/AdditionalInfoForm.js
@@ -10,13 +10,13 @@ import { routeWithParams } from 'lib/utils/routes';
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
-function AdditionalInfoForm({ id, onSave }) {
+function AdditionalInfoForm({ id, onSave, request }) {
   const history = useHistory();
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState({
-    additionalInfo: '',
+    additionalInfo: request?.additionalInfo || '',
   });
 
   const handleFieldChange = useCallback(
@@ -51,7 +51,6 @@ function AdditionalInfoForm({ id, onSave }) {
       onSubmit={handleSubmit}
       title={t('service.additionalInfo.title')}
       description={t('service.additionalInfo.description')}
-      disabled={!Object.keys(fields).every((key) => !!fields[key])}
       fields={fieldData}
       isLoading={isLoading}
     />

--- a/src/containers/ChildcareFormLocation.js
+++ b/src/containers/ChildcareFormLocation.js
@@ -16,13 +16,19 @@ import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 import { neighborhoods } from 'data/neighborhoods';
 
-const validate = (val) => {
+const validatePhone = (val) => {
+  if (val === '') {
+    return;
+  }
   if (!isValidPhoneNumber(val)) {
     return 'Please enter a valid phone number';
   }
 };
 
 const validateEmail = (val) => {
+  if (val === '') {
+    return;
+  }
   if (!isValidEmail(val)) {
     return 'Please enter a valid email address';
   }
@@ -33,9 +39,10 @@ function ChildcareFormLocation({ id, onSave, request }) {
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [addAdditionalContact, setAddAdditionalContact] = useState(false);
+  const [addAdditionalContact, setAddAdditionalContact] = useState(
+    !!request?.additionalContactFirstName,
+  );
   const [fields, setFields] = useState({
-    zipCode: request?.zipCode || '',
     neighborhood: request?.neighborhood || '',
     crossStreet: request?.crossStreet || '',
   });
@@ -50,22 +57,42 @@ function ChildcareFormLocation({ id, onSave, request }) {
     [],
   );
 
+  const handleAdditionalFieldChange = useCallback(
+    (field) => (value) => {
+      setAdditionalFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
+  const [additionalFields, setAdditionalFields] = useState({
+    additionalContactFirstName: request?.additionalContactFirstName || '',
+    additionalContactLastName: request?.additionalContactLastName || '',
+    additionalContactRelationship: request?.additionalContactRelationship || '',
+    additionalContactEmail: request?.additionalContactEmail || '',
+    additionalContactPhone: request?.additionalContactPhone || '',
+    additionalContactContactPreference:
+      request?.additionalContactContactPreference || '',
+    additionalContactLanguagePreference:
+      request?.additionalContactLanguagePreference || '',
+  });
+
   const handleSubmit = async () => {
     setIsLoading(true);
-    await onSave(fields);
+    if (addAdditionalContact) {
+      await onSave({ ...fields, ...additionalFields });
+    } else {
+      await onSave(fields);
+    }
     history.push(routeWithParams(Routes.SERVICE_CHILDCARE_WHEN, { id }));
   };
 
   const fieldData = [
     {
-      customOnChange: handleFieldChange('zipCode'),
-      label: t('service.childcare.where.labels.zip'),
-      name: 'zipCode',
-      type: formFieldTypes.INPUT_TEXT,
-      value: fields.zipCode,
-    },
-    {
       customOnChange: handleFieldChange('neighborhood'),
+      defaultValue: fields.neighborhood,
       label: t('service.childcare.where.labels.neighborhood'),
       // service todo: wire-up neighborhoods data
       options: neighborhoods.Brooklyn,
@@ -75,6 +102,7 @@ function ChildcareFormLocation({ id, onSave, request }) {
     },
     {
       customOnChange: handleFieldChange('crossStreet'),
+      defaultValue: fields.crossStreet,
       label: t('service.childcare.where.labels.crossStreet'),
       name: 'crossStreet',
       type: formFieldTypes.INPUT_TEXT,
@@ -94,60 +122,106 @@ function ChildcareFormLocation({ id, onSave, request }) {
     },
   ];
 
-  const additionalContactFields = [
+  const additionalContactFieldData = [
     {
-      customOnChange: handleFieldChange('firstName'),
+      customOnChange: handleAdditionalFieldChange('additionalContactFirstName'),
+      defaultValue: additionalFields.additionalContactFirstName,
       label: t('service.contactForm.labels.firstName'),
-      name: 'firstName',
+      name: 'additionalContactFirstName',
       type: formFieldTypes.INPUT_TEXT,
+      value: additionalFields.additionalContactFirstName,
     },
     {
-      customOnChange: handleFieldChange('lastName'),
-      label: t('service.additionalContact.labels.lastName'),
-      name: 'lastName',
-      type: formFieldTypes.INPUT_TEXT,
-    },
-    {
-      customOnChange: handleFieldChange('relationship'),
-      label: t('service.additionalContact.labels.relationship'),
-      options: [
-        { label: 'Partner', value: 'partner' },
-        { label: 'Family member', value: 'family-member' },
-        { label: 'Friend', value: 'friend' },
-      ],
-      name: 'relationship',
-      type: formFieldTypes.INPUT_DROPDOWN,
-    },
-    {
-      customOnChange: handleFieldChange('email'),
-      label: t('service.additionalContact.labels.email'),
-      name: 'email',
-      type: formFieldTypes.INPUT_TEXT,
-      validation: { validateEmail },
-    },
-    {
-      customOnChange: handleFieldChange('phone'),
+      customOnChange: handleAdditionalFieldChange('additionalContactLastName'),
+      defaultValue: additionalFields.additionalContactLastName,
       isRequired: false,
-      label: t('service.contactForm.labels.phone'),
-      name: 'phone',
+      label: t('service.additionalContact.labels.lastName'),
+      name: 'additionalContactLastName',
       type: formFieldTypes.INPUT_TEXT,
-      validation: { validate },
+      value: additionalFields.additionalContactLastName,
     },
     {
-      customOnChange: handleFieldChange('contactPreference'),
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactRelationship',
+      ),
+      defaultValue: additionalFields.additionalContactRelationship,
+      isRequired: false,
+      label: t('service.additionalContact.labels.relationship'),
+      name: 'additionalContactRelationship',
+      type: formFieldTypes.INPUT_TEXT,
+      value: additionalFields.additionalContactRelationship,
+    },
+    {
+      customOnChaonge: handleAdditionalFieldChange('additionalContactEmail'),
+      defaultValue: additionalFields.additionalContactEmail,
+      isRequired: false,
+      label: t('service.additionalContact.labels.email'),
+      name: 'additionalContactEmail',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate: validateEmail },
+      value: additionalFields.additionalContactEmail,
+    },
+    {
+      customOnChange: handleAdditionalFieldChange('additionalContactPhone'),
+      defaultValue: additionalFields.additionalContactPhone,
+      label: t('service.contactForm.labels.phone'),
+      name: 'additionalContactPhone',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate: validatePhone },
+      value: additionalFields.additionalContactPhone,
+    },
+    {
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactContactPreference',
+      ),
+      defaultValue: additionalFields.additionalContactContactPreference,
       label: t('service.contactForm.labels.contactPreference'),
       options: CONTACT_PREFERENCES,
-      name: 'contactPreference',
+      name: 'additionalContactContactPreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: additionalFields.additionalContactContactPreference,
     },
     {
-      customOnChange: handleFieldChange('languagePreference'),
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactLanguagePreference',
+      ),
+      defaultValue: additionalFields.additionalContactLanguagePreference,
       label: t('service.contactForm.labels.languagePreference'),
       options: LANGUAGES,
-      name: 'languagePreference',
+      name: 'additionalContactLanguagePreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: additionalFields.additionalContactLanguagePreference,
     },
   ];
+
+  const {
+    additionalContactLastName,
+    additionalContactRelationship,
+    additionalContactEmail,
+    ...additionalRequiredFields
+  } = additionalFields;
+
+  if (addAdditionalContact) {
+    return (
+      <FormBuilder
+        defaultValues={{ ...fields, ...additionalFields }}
+        onSubmit={handleSubmit}
+        title={t('service.childcare.where.title')}
+        description={t('service.childcare.where.description')}
+        disabled={
+          (additionalFields.additionalContactPhone !== '' &&
+            !isValidPhoneNumber(additionalFields.additionalContactPhone)) ||
+          (additionalFields.additionalContactEmail !== '' &&
+            !isValidEmail(additionalFields.additionalContactEmail)) ||
+          !Object.keys({ ...fields, ...additionalRequiredFields }).every(
+            (key) => !!{ ...fields, ...additionalRequiredFields }[key],
+          )
+        }
+        fields={[...fieldData, ...additionalContactFieldData]}
+        isLoading={isLoading}
+      />
+    );
+  }
 
   return (
     <FormBuilder
@@ -156,11 +230,7 @@ function ChildcareFormLocation({ id, onSave, request }) {
       title={t('service.childcare.where.title')}
       description={t('service.childcare.where.description')}
       disabled={!Object.keys(fields).every((key) => !!fields[key])}
-      fields={
-        addAdditionalContact
-          ? [...fieldData, ...additionalContactFields]
-          : fieldData
-      }
+      fields={fieldData}
       isLoading={isLoading}
     />
   );

--- a/src/containers/ChildcareFormOptions.js
+++ b/src/containers/ChildcareFormOptions.js
@@ -95,6 +95,7 @@ function ChildcareFormDetails({ id, onSave, request }) {
     },
     {
       customOnChange: handleFieldChange('paymentAbility'),
+      isRequired: false,
       label: t('service.childcare.what.labels.paymentAbility'),
       name: 'paymentAbility',
       type: formFieldTypes.INPUT_TEXT,
@@ -129,6 +130,16 @@ function ChildcareFormDetails({ id, onSave, request }) {
     },
   ];
 
+  const {
+    childCareCenters,
+    mutualAid,
+    enrichmentCenters,
+    babySitters,
+    freeOptions,
+    paymentAbility,
+    ...requiredFields
+  } = fields;
+
   return (
     <div>
       <FormBuilder
@@ -136,7 +147,7 @@ function ChildcareFormDetails({ id, onSave, request }) {
         onSubmit={handleSubmit}
         title={t('service.childcare.what.title')}
         description={t('service.childcare.what.description')}
-        disabled={!Object.keys(fields).every((key) => !!fields[key])}
+        disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
         fields={fieldData}
         isLoading={isLoading}
       />

--- a/src/containers/EmotionalFormDate.js
+++ b/src/containers/EmotionalFormDate.js
@@ -11,15 +11,15 @@ import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 import Note from 'components/Note';
 
-function EmotionalFormDate({ id, onSave }) {
+function EmotionalFormDate({ id, onSave, request }) {
   const history = useHistory();
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState({
-    date: '',
-    time: '',
-    recurring: '',
+    date: request?.date || '',
+    time: request?.time || '',
+    recurring: request?.recurring || '',
   });
 
   const handleFieldChange = useCallback(
@@ -41,6 +41,7 @@ function EmotionalFormDate({ id, onSave }) {
   const fieldData = [
     {
       customOnChange: handleFieldChange('date'),
+      defaultValue: fields.date,
       label: t('service.emotional.when.labels.day'),
       options: [
         { label: 'Monday', value: 'monday' },
@@ -57,6 +58,7 @@ function EmotionalFormDate({ id, onSave }) {
     },
     {
       customOnChange: handleFieldChange('time'),
+      defaultValue: fields.time,
       label: t('service.emotional.when.labels.time'),
       options: [
         { label: 'Morning', value: 'morning' },
@@ -85,13 +87,15 @@ function EmotionalFormDate({ id, onSave }) {
     },
   ];
 
+  const { recurring, ...requiredFields } = fields;
+
   return (
     <FormBuilder
       defaultValues={fields}
       onSubmit={handleSubmit}
       title={t('service.emotional.when.title')}
       description={t('service.emotional.when.description')}
-      disabled={!Object.keys(fields).every((key) => !!fields[key])}
+      disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
       fields={fieldData}
       isLoading={isLoading}
     />

--- a/src/containers/EmotionalFormType.js
+++ b/src/containers/EmotionalFormType.js
@@ -10,14 +10,14 @@ import { routeWithParams } from 'lib/utils/routes';
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 
-function EmotionalFormDate({ id, onSave }) {
+function EmotionalFormDate({ id, onSave, request }) {
   const history = useHistory();
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState({
-    type: '',
-    agreement: '',
+    type: request?.type || '',
+    agreement: request?.agreement || '',
   });
 
   const handleFieldChange = useCallback(
@@ -39,6 +39,7 @@ function EmotionalFormDate({ id, onSave }) {
   const fieldData = [
     {
       customOnChange: handleFieldChange('type'),
+      defaultValue: fields.type,
       label: t('service.emotional.what.labels.type'),
       options: [
         { label: 'Licensed Mental Health Professional', value: 'licensed' },

--- a/src/containers/GroceryFormDate.js
+++ b/src/containers/GroceryFormDate.js
@@ -17,7 +17,7 @@ function GroceryFormDate({ id, onSave, request }) {
 
   const [isLoading, setIsLoading] = useState(false);
   const [fields, setFields] = useState({
-    date: request?.date || '',
+    date: request?.date?.toDate() || '',
     time: request?.time || '',
     recurring: request?.recurring || false,
   });
@@ -32,6 +32,8 @@ function GroceryFormDate({ id, onSave, request }) {
     [],
   );
 
+  const { recurring, ...requiredFields } = fields;
+
   const handleSubmit = async () => {
     setIsLoading(true);
     await onSave(fields);
@@ -41,6 +43,7 @@ function GroceryFormDate({ id, onSave, request }) {
   const fieldData = [
     {
       customOnChange: handleFieldChange('date'),
+      defaultValue: fields.date,
       label: t('service.grocery.when.labels.day'),
       name: 'date',
       type: formFieldTypes.INPUT_DATE,
@@ -48,6 +51,7 @@ function GroceryFormDate({ id, onSave, request }) {
     },
     {
       customOnChange: handleFieldChange('time'),
+      isRequired: false,
       label: t('service.grocery.when.labels.time'),
       options: [
         { label: 'Morning', value: 'morning' },
@@ -82,7 +86,7 @@ function GroceryFormDate({ id, onSave, request }) {
       onSubmit={handleSubmit}
       title={t('service.grocery.when.title')}
       description={t('service.grocery.when.description')}
-      disabled={!Object.keys(fields).every((key) => !!fields[key])}
+      disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
       fields={fieldData}
       isLoading={isLoading}
     />

--- a/src/containers/GroceryFormItems.js
+++ b/src/containers/GroceryFormItems.js
@@ -30,6 +30,8 @@ function GroceryFormItems({ id, onSave, request }) {
     [],
   );
 
+  const { dietaryRestrictions, ...requiredFields } = fields;
+
   const handleSubmit = async () => {
     setIsLoading(true);
     await onSave(fields);
@@ -46,6 +48,7 @@ function GroceryFormItems({ id, onSave, request }) {
     },
     {
       customOnChange: handleFieldChange('dietaryRestrictions'),
+      isRequired: false,
       label: t('service.grocery.what.labels.dietaryRestrictions'),
       name: 'dietaryRestrictions',
       type: formFieldTypes.INPUT_TEXT,
@@ -59,7 +62,7 @@ function GroceryFormItems({ id, onSave, request }) {
       onSubmit={handleSubmit}
       title={t('service.grocery.what.title')}
       description={t('service.grocery.what.description')}
-      disabled={!Object.keys(fields).every((key) => !!fields[key])}
+      disabled={!Object.keys(requiredFields).every((key) => !!fields[key])}
       fields={fieldData}
       isLoading={isLoading}
     />

--- a/src/containers/GroceryFormLocation.js
+++ b/src/containers/GroceryFormLocation.js
@@ -16,13 +16,19 @@ import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 import { neighborhoods } from 'data/neighborhoods';
 
-const validate = (val) => {
+const validatePhone = (val) => {
+  if (val === '') {
+    return;
+  }
   if (!isValidPhoneNumber(val)) {
     return 'Please enter a valid phone number';
   }
 };
 
 const validateEmail = (val) => {
+  if (val === '') {
+    return;
+  }
   if (!isValidEmail(val)) {
     return 'Please enter a valid email address';
   }
@@ -33,9 +39,10 @@ function GroceryFormLocation({ id, onSave, request }) {
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [addAdditionalContact, setAddAdditionalContact] = useState(false);
+  const [addAdditionalContact, setAddAdditionalContact] = useState(
+    !!request?.additionalContactFirstName,
+  );
   const [fields, setFields] = useState({
-    zipCode: request?.zipCode || '',
     neighborhood: request?.neighborhood || '',
     crossStreet: request?.crossStreet || '',
   });
@@ -50,22 +57,42 @@ function GroceryFormLocation({ id, onSave, request }) {
     [],
   );
 
+  const [additionalFields, setAdditionalFields] = useState({
+    additionalContactFirstName: request?.additionalContactFirstName || '',
+    additionalContactLastName: request?.additionalContactLastName || '',
+    additionalContactRelationship: request?.additionalContactRelationship || '',
+    additionalContactEmail: request?.additionalContactEmail || '',
+    additionalContactPhone: request?.additionalContactPhone || '',
+    additionalContactContactPreference:
+      request?.additionalContactContactPreference || '',
+    additionalContactLanguagePreference:
+      request?.additionalContactLanguagePreference || '',
+  });
+
+  const handleAdditionalFieldChange = useCallback(
+    (field) => (value) => {
+      setAdditionalFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
   const handleSubmit = async () => {
     setIsLoading(true);
-    await onSave(fields);
+    if (addAdditionalContact) {
+      await onSave({ ...fields, ...additionalFields });
+    } else {
+      await onSave(fields);
+    }
     history.push(routeWithParams(Routes.SERVICE_GROCERIES_WHEN, { id }));
   };
 
   const fieldData = [
     {
-      customOnChange: handleFieldChange('zipCode'),
-      label: t('service.grocery.where.labels.zip'),
-      name: 'zipCode',
-      type: formFieldTypes.INPUT_TEXT,
-      value: fields.zipCode,
-    },
-    {
       customOnChange: handleFieldChange('neighborhood'),
+      defaultValue: fields.neighborhood,
       label: t('service.grocery.where.labels.neighborhood'),
       // service todo: wire-up neighborhoods data
       options: neighborhoods.Brooklyn,
@@ -75,6 +102,7 @@ function GroceryFormLocation({ id, onSave, request }) {
     },
     {
       customOnChange: handleFieldChange('crossStreet'),
+      defaultValue: fields.crossStreet,
       label: t('service.grocery.where.labels.crossStreet'),
       name: 'crossStreet',
       type: formFieldTypes.INPUT_TEXT,
@@ -94,61 +122,106 @@ function GroceryFormLocation({ id, onSave, request }) {
     },
   ];
 
-  const additionalContactFields = [
+  const additionalContactFieldData = [
     {
-      customOnChange: handleFieldChange('firstName'),
+      customOnChange: handleAdditionalFieldChange('additionalContactFirstName'),
+      defaultValue: additionalFields.additionalContactFirstName,
       label: t('service.contactForm.labels.firstName'),
-      name: 'firstName',
+      name: 'additionalContactFirstName',
       type: formFieldTypes.INPUT_TEXT,
+      value: additionalFields.additionalContactFirstName,
     },
     {
-      customOnChange: handleFieldChange('lastName'),
-      label: t('service.additionalContact.labels.lastName'),
-      name: 'lastName',
-      type: formFieldTypes.INPUT_TEXT,
-    },
-    {
-      customOnChange: handleFieldChange('relationship'),
-      label: t('service.additionalContact.labels.relationship'),
-      options: [
-        { label: 'Partner', value: 'partner' },
-        { label: 'Family member', value: 'family-member' },
-        { label: 'Friend', value: 'friend' },
-      ],
-      name: 'relationship',
-      type: formFieldTypes.INPUT_DROPDOWN,
-    },
-    {
-      customOnChange: handleFieldChange('email'),
-      label: t('service.additionalContact.labels.email'),
-      name: 'email',
-      type: formFieldTypes.INPUT_TEXT,
-      validation: { validateEmail },
-    },
-    {
-      customOnChange: handleFieldChange('phone'),
+      customOnChange: handleAdditionalFieldChange('additionalContactLastName'),
+      defaultValue: additionalFields.additionalContactLastName,
       isRequired: false,
-      label: t('service.contactForm.labels.phone'),
-      name: 'phone',
+      label: t('service.additionalContact.labels.lastName'),
+      name: 'additionalContactLastName',
       type: formFieldTypes.INPUT_TEXT,
-      validation: { validate },
+      value: additionalFields.additionalContactLastName,
     },
     {
-      customOnChange: handleFieldChange('contactPreference'),
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactRelationship',
+      ),
+      defaultValue: additionalFields.additionalContactRelationship,
+      isRequired: false,
+      label: t('service.additionalContact.labels.relationship'),
+      name: 'additionalContactRelationship',
+      type: formFieldTypes.INPUT_TEXT,
+      value: additionalFields.additionalContactRelationship,
+    },
+    {
+      customOnChaonge: handleAdditionalFieldChange('additionalContactEmail'),
+      defaultValue: additionalFields.additionalContactEmail,
+      isRequired: false,
+      label: t('service.additionalContact.labels.email'),
+      name: 'additionalContactEmail',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate: validateEmail },
+      value: additionalFields.additionalContactEmail,
+    },
+    {
+      customOnChange: handleAdditionalFieldChange('additionalContactPhone'),
+      defaultValue: additionalFields.additionalContactPhone,
+      label: t('service.contactForm.labels.phone'),
+      name: 'additionalContactPhone',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate: validatePhone },
+      value: additionalFields.additionalContactPhone,
+    },
+    {
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactContactPreference',
+      ),
+      defaultValue: additionalFields.additionalContactContactPreference,
       label: t('service.contactForm.labels.contactPreference'),
       options: CONTACT_PREFERENCES,
-      name: 'contactPreference',
+      name: 'additionalContactContactPreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: additionalFields.additionalContactContactPreference,
     },
     {
-      customOnChange: handleFieldChange('languagePreference'),
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactLanguagePreference',
+      ),
+      defaultValue: additionalFields.additionalContactLanguagePreference,
       label: t('service.contactForm.labels.languagePreference'),
       options: LANGUAGES,
-      name: 'languagePreference',
+      name: 'additionalContactLanguagePreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: additionalFields.additionalContactLanguagePreference,
     },
   ];
 
+  const {
+    additionalContactLastName,
+    additionalContactRelationship,
+    additionalContactEmail,
+    ...additionalRequiredFields
+  } = additionalFields;
+
+  if (addAdditionalContact) {
+    return (
+      <FormBuilder
+        defaultValues={{ ...fields, ...additionalFields }}
+        onSubmit={handleSubmit}
+        title={t('service.grocery.where.title')}
+        description={t('service.grocery.where.description')}
+        disabled={
+          (additionalFields.additionalContactPhone !== '' &&
+            !isValidPhoneNumber(additionalFields.additionalContactPhone)) ||
+          (additionalFields.additionalContactEmail !== '' &&
+            !isValidEmail(additionalFields.additionalContactEmail)) ||
+          !Object.keys({ ...fields, ...additionalRequiredFields }).every(
+            (key) => !!{ ...fields, ...additionalRequiredFields }[key],
+          )
+        }
+        fields={[...fieldData, ...additionalContactFieldData]}
+        isLoading={isLoading}
+      />
+    );
+  }
   return (
     <FormBuilder
       defaultValues={fields}
@@ -156,11 +229,7 @@ function GroceryFormLocation({ id, onSave, request }) {
       title={t('service.grocery.where.title')}
       description={t('service.grocery.where.description')}
       disabled={!Object.keys(fields).every((key) => !!fields[key])}
-      fields={
-        addAdditionalContact
-          ? [...fieldData, ...additionalContactFields]
-          : fieldData
-      }
+      fields={fieldData}
       isLoading={isLoading}
     />
   );

--- a/src/containers/PetcareFormLocation.js
+++ b/src/containers/PetcareFormLocation.js
@@ -16,28 +16,35 @@ import { formFieldTypes } from 'components/Form/CreateFormFields';
 
 import { neighborhoods } from 'data/neighborhoods';
 
-const validate = (val) => {
+const validatePhone = (val) => {
+  if (val === '') {
+    return;
+  }
   if (!isValidPhoneNumber(val)) {
     return 'Please enter a valid phone number';
   }
 };
 
 const validateEmail = (val) => {
+  if (val === '') {
+    return;
+  }
   if (!isValidEmail(val)) {
     return 'Please enter a valid email address';
   }
 };
 
-function PetcareFormLocation({ id, onSave }) {
+function PetcareFormLocation({ id, onSave, request }) {
   const history = useHistory();
   const { t } = useTranslation();
 
   const [isLoading, setIsLoading] = useState(false);
-  const [addAdditionalContact, setAddAdditionalContact] = useState(false);
+  const [addAdditionalContact, setAddAdditionalContact] = useState(
+    !!request?.additionalContactFirstName,
+  );
   const [fields, setFields] = useState({
-    zipCode: '',
-    neighborhood: '',
-    crossStreet: '',
+    neighborhood: request?.neighborhood || '',
+    crossStreet: request?.crossStreet || '',
   });
 
   const handleFieldChange = useCallback(
@@ -50,22 +57,42 @@ function PetcareFormLocation({ id, onSave }) {
     [],
   );
 
+  const [additionalFields, setAdditionalFields] = useState({
+    additionalContactFirstName: request?.additionalContactFirstName || '',
+    additionalContactLastName: request?.additionalContactLastName || '',
+    additionalContactRelationship: request?.additionalContactRelationship || '',
+    additionalContactEmail: request?.additionalContactEmail || '',
+    additionalContactPhone: request?.additionalContactPhone || '',
+    additionalContactContactPreference:
+      request?.additionalContactContactPreference || '',
+    additionalContactLanguagePreference:
+      request?.additionalContactLanguagePreference || '',
+  });
+
+  const handleAdditionalFieldChange = useCallback(
+    (field) => (value) => {
+      setAdditionalFields((fields) => ({
+        ...fields,
+        [field]: value,
+      }));
+    },
+    [],
+  );
+
   const handleSubmit = async () => {
     setIsLoading(true);
-    await onSave(fields);
+    if (addAdditionalContact) {
+      await onSave({ ...fields, ...additionalFields });
+    } else {
+      await onSave(fields);
+    }
     history.push(routeWithParams(Routes.SERVICE_PETCARE_WHEN, { id }));
   };
 
   const fieldData = [
     {
-      customOnChange: handleFieldChange('zipCode'),
-      label: t('service.petcare.where.labels.zip'),
-      name: 'zipCode',
-      type: formFieldTypes.INPUT_TEXT,
-      value: fields.zipCode,
-    },
-    {
       customOnChange: handleFieldChange('neighborhood'),
+      defaultValue: fields.neighborhood,
       label: t('service.petcare.where.labels.neighborhood'),
       // service todo: wire-up neighborhoods data
       options: neighborhoods.Brooklyn,
@@ -75,6 +102,7 @@ function PetcareFormLocation({ id, onSave }) {
     },
     {
       customOnChange: handleFieldChange('crossStreet'),
+      defaultValue: fields.crossStreet,
       label: t('service.petcare.where.labels.crossStreet'),
       name: 'crossStreet',
       type: formFieldTypes.INPUT_TEXT,
@@ -94,60 +122,106 @@ function PetcareFormLocation({ id, onSave }) {
     },
   ];
 
-  const additionalContactFields = [
+  const additionalContactFieldData = [
     {
-      customOnChange: handleFieldChange('firstName'),
+      customOnChange: handleAdditionalFieldChange('additionalContactFirstName'),
+      defaultValue: additionalFields.additionalContactFirstName,
       label: t('service.contactForm.labels.firstName'),
-      name: 'firstName',
+      name: 'additionalContactFirstName',
       type: formFieldTypes.INPUT_TEXT,
+      value: additionalFields.additionalContactFirstName,
     },
     {
-      customOnChange: handleFieldChange('lastName'),
-      label: t('service.additionalContact.labels.lastName'),
-      name: 'lastName',
-      type: formFieldTypes.INPUT_TEXT,
-    },
-    {
-      customOnChange: handleFieldChange('relationship'),
-      label: t('service.additionalContact.labels.relationship'),
-      options: [
-        { label: 'Partner', value: 'partner' },
-        { label: 'Family member', value: 'family-member' },
-        { label: 'Friend', value: 'friend' },
-      ],
-      name: 'relationship',
-      type: formFieldTypes.INPUT_DROPDOWN,
-    },
-    {
-      customOnChange: handleFieldChange('email'),
-      label: t('service.additionalContact.labels.email'),
-      name: 'email',
-      type: formFieldTypes.INPUT_TEXT,
-      validation: { validateEmail },
-    },
-    {
-      customOnChange: handleFieldChange('phone'),
+      customOnChange: handleAdditionalFieldChange('additionalContactLastName'),
+      defaultValue: additionalFields.additionalContactLastName,
       isRequired: false,
-      label: t('service.contactForm.labels.phone'),
-      name: 'phone',
+      label: t('service.additionalContact.labels.lastName'),
+      name: 'additionalContactLastName',
       type: formFieldTypes.INPUT_TEXT,
-      validation: { validate },
+      value: additionalFields.additionalContactLastName,
     },
     {
-      customOnChange: handleFieldChange('contactPreference'),
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactRelationship',
+      ),
+      defaultValue: additionalFields.additionalContactRelationship,
+      isRequired: false,
+      label: t('service.additionalContact.labels.relationship'),
+      name: 'additionalContactRelationship',
+      type: formFieldTypes.INPUT_TEXT,
+      value: additionalFields.additionalContactRelationship,
+    },
+    {
+      customOnChaonge: handleAdditionalFieldChange('additionalContactEmail'),
+      defaultValue: additionalFields.additionalContactEmail,
+      isRequired: false,
+      label: t('service.additionalContact.labels.email'),
+      name: 'additionalContactEmail',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate: validateEmail },
+      value: additionalFields.additionalContactEmail,
+    },
+    {
+      customOnChange: handleAdditionalFieldChange('additionalContactPhone'),
+      defaultValue: additionalFields.additionalContactPhone,
+      label: t('service.contactForm.labels.phone'),
+      name: 'additionalContactPhone',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate: validatePhone },
+      value: additionalFields.additionalContactPhone,
+    },
+    {
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactContactPreference',
+      ),
+      defaultValue: additionalFields.additionalContactContactPreference,
       label: t('service.contactForm.labels.contactPreference'),
       options: CONTACT_PREFERENCES,
-      name: 'contactPreference',
+      name: 'additionalContactContactPreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: additionalFields.additionalContactContactPreference,
     },
     {
-      customOnChange: handleFieldChange('languagePreference'),
+      customOnChange: handleAdditionalFieldChange(
+        'additionalContactLanguagePreference',
+      ),
+      defaultValue: additionalFields.additionalContactLanguagePreference,
       label: t('service.contactForm.labels.languagePreference'),
       options: LANGUAGES,
-      name: 'languagePreference',
+      name: 'additionalContactLanguagePreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: additionalFields.additionalContactLanguagePreference,
     },
   ];
+
+  const {
+    additionalContactLastName,
+    additionalContactRelationship,
+    additionalContactEmail,
+    ...additionalRequiredFields
+  } = additionalFields;
+
+  if (addAdditionalContact) {
+    return (
+      <FormBuilder
+        defaultValues={{ ...fields, ...additionalFields }}
+        onSubmit={handleSubmit}
+        title={t('service.petcare.where.title')}
+        description={t('service.petcare.where.description')}
+        disabled={
+          (additionalFields.additionalContactPhone !== '' &&
+            !isValidPhoneNumber(additionalFields.additionalContactPhone)) ||
+          (additionalFields.additionalContactEmail !== '' &&
+            !isValidEmail(additionalFields.additionalContactEmail)) ||
+          !Object.keys({ ...fields, ...additionalRequiredFields }).every(
+            (key) => !!{ ...fields, ...additionalRequiredFields }[key],
+          )
+        }
+        fields={[...fieldData, ...additionalContactFieldData]}
+        isLoading={isLoading}
+      />
+    );
+  }
 
   return (
     <FormBuilder
@@ -156,11 +230,7 @@ function PetcareFormLocation({ id, onSave }) {
       title={t('service.petcare.where.title')}
       description={t('service.petcare.where.description')}
       disabled={!Object.keys(fields).every((key) => !!fields[key])}
-      fields={
-        addAdditionalContact
-          ? [...fieldData, ...additionalContactFields]
-          : fieldData
-      }
+      fields={fieldData}
       isLoading={isLoading}
     />
   );

--- a/src/containers/ServiceContactForm.js
+++ b/src/containers/ServiceContactForm.js
@@ -66,30 +66,38 @@ function ServiceContactForm({ backend, serviceUser }) {
   const fieldData = [
     {
       customOnChange: handleFieldChange('firstName'),
+      defaultValue: fields.firstName,
       label: t('service.contactForm.labels.firstName'),
       name: 'firstName',
       type: formFieldTypes.INPUT_TEXT,
+      value: fields.firstName,
     },
     {
       customOnChange: handleFieldChange('lastName'),
+      defaultValue: fields.lastName,
       label: t('service.contactForm.labels.lastName'),
       name: 'lastName',
       type: formFieldTypes.INPUT_TEXT,
+      value: fields.lastName,
     },
     {
       customOnChange: handleFieldChange('phone'),
+      defaultValue: fields.phone,
       isRequired: false,
       label: t('service.contactForm.labels.phone'),
       name: 'phone',
       type: formFieldTypes.INPUT_TEXT,
       validation: { validate },
+      value: fields.phone,
     },
     {
       customOnChange: handleFieldChange('contactPreference'),
+      defaultValue: fields.contactPreference,
       label: t('service.contactForm.labels.contactPreference'),
       options: CONTACT_PREFERENCES,
       name: 'contactPreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: fields.contactPreference,
     },
     {
       type: formFieldTypes.NODE,
@@ -101,10 +109,12 @@ function ServiceContactForm({ backend, serviceUser }) {
     },
     {
       customOnChange: handleFieldChange('languagePreference'),
+      defaultValue: fields.languagePreference,
       label: t('service.contactForm.labels.languagePreference'),
       options: LANGUAGES,
       name: 'languagePreference',
       type: formFieldTypes.INPUT_DROPDOWN,
+      value: fields.languagePreference,
     },
   ];
 

--- a/src/pages/service_additional_info.js
+++ b/src/pages/service_additional_info.js
@@ -1,16 +1,32 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
 import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 
 import Page from 'components/layouts/Page';
 import AdditionalInfoForm from 'containers/AdditionalInfoForm';
 
 function ServiceAdditionalInfo({ backend }) {
+  const [request, setRequest] = useState();
   const params = useParams();
 
   const updateService = (request) => {
     backend.updateServiceRequest(params.id, request, true);
   };
+
+  useEffect(() => {
+    if (!params.id) {
+      return;
+    }
+    backend.getServiceRequest(params.id).then((data) => {
+      setRequest(data);
+    });
+  }, [backend, params.id]);
+
+  if (params.id && !request) {
+    // loading
+    return null;
+  }
 
   return (
     <Page currentProgress={4} totalProgress={5}>
@@ -18,6 +34,7 @@ function ServiceAdditionalInfo({ backend }) {
         backend={backend}
         id={params.id}
         onSave={updateService}
+        request={request}
       />
     </Page>
   );

--- a/src/pages/service_childcare.js
+++ b/src/pages/service_childcare.js
@@ -1,17 +1,18 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
+import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 
 import Page from 'components/layouts/Page';
 import ChildcareFormLocation from 'containers/ChildcareFormLocation';
 import ChildcareFormDate from 'containers/ChildcareFormDate';
 import ChildcareFormDetails from 'containers/ChildcareFormDetails';
 import ChildcareFormOptions from 'containers/ChildcareFormOptions';
-import { useParams } from 'react-router-dom';
-import { useState, useEffect } from 'react';
 
 function ServiceChildcare({ backend, step }) {
   const [request, setRequest] = useState();
   const params = useParams();
+
   const updateService = (request) => {
     backend.updateServiceRequest(params.id, request, true);
   };

--- a/src/pages/service_emotional.js
+++ b/src/pages/service_emotional.js
@@ -1,24 +1,49 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
+import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 
 import Page from 'components/layouts/Page';
 import EmotionalFormDate from 'containers/EmotionalFormDate';
 import EmotionalFormType from 'containers/EmotionalFormType';
-import { useParams } from 'react-router-dom';
 
 function ServiceEmotional({ backend, step }) {
+  const [request, setRequest] = useState(null);
   const params = useParams();
 
   const updateService = (request) => {
     backend.updateServiceRequest(params.id, request, true);
   };
+
+  useEffect(() => {
+    if (!params.id) {
+      return;
+    }
+    backend.getServiceRequest(params.id).then((data) => {
+      setRequest(data);
+    });
+  }, [backend, params.id]);
+
+  if (params.id && !request) {
+    // loading
+    return null;
+  }
+
   return (
     <Page currentProgress={4} totalProgress={5}>
       {step === 1 && (
-        <EmotionalFormDate onSave={updateService} id={params.id} />
+        <EmotionalFormDate
+          request={request}
+          onSave={updateService}
+          id={params.id}
+        />
       )}
       {step === 2 && (
-        <EmotionalFormType onSave={updateService} id={params.id} />
+        <EmotionalFormType
+          request={request}
+          onSave={updateService}
+          id={params.id}
+        />
       )}
     </Page>
   );

--- a/src/pages/service_grocery.js
+++ b/src/pages/service_grocery.js
@@ -1,15 +1,15 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
+import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 
 import Page from 'components/layouts/Page';
 import GroceryFormLocation from 'containers/GroceryFormLocation';
 import GroceryFormDate from 'containers/GroceryFormDate';
 import GroceryFormItems from 'containers/GroceryFormItems';
-import { useParams } from 'react-router-dom';
-import { useState, useEffect } from 'react';
 
 function ServiceGrocery({ backend, step }) {
-  const [request, setRequest] = useState(request);
+  const [request, setRequest] = useState(null);
   const params = useParams();
 
   const updateService = (request) => {

--- a/src/pages/service_petcare.js
+++ b/src/pages/service_petcare.js
@@ -1,26 +1,57 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
+import { useParams } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 
 import Page from 'components/layouts/Page';
 import PetcareFormLocation from 'containers/PetcareFormLocation';
 import PetcareFormDate from 'containers/PetcareFormDate';
 import PetcareFormDetails from 'containers/PetcareFormDetails';
-import { useParams } from 'react-router-dom';
 
 function ServicePetcare({ backend, step }) {
+  const [request, setRequest] = useState(null);
   const params = useParams();
 
   const updateService = (request) => {
     backend.updateServiceRequest(params.id, request, true);
   };
+
+  useEffect(() => {
+    if (!params.id) {
+      return;
+    }
+    backend.getServiceRequest(params.id).then((data) => {
+      setRequest(data);
+    });
+  }, [backend, params.id]);
+
+  if (params.id && !request) {
+    // loading
+    return null;
+  }
+
   return (
     <Page currentProgress={4} totalProgress={5}>
       {step === 1 && (
-        <PetcareFormLocation onSave={updateService} id={params.id} />
+        <PetcareFormLocation
+          request={request}
+          onSave={updateService}
+          id={params.id}
+        />
       )}
-      {step === 2 && <PetcareFormDate onSave={updateService} id={params.id} />}
+      {step === 2 && (
+        <PetcareFormDate
+          request={request}
+          onSave={updateService}
+          id={params.id}
+        />
+      )}
       {step === 3 && (
-        <PetcareFormDetails onSave={updateService} id={params.id} />
+        <PetcareFormDetails
+          request={request}
+          onSave={updateService}
+          id={params.id}
+        />
       )}
     </Page>
   );


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/152/optional-fields-are-returning-an-error-when-not-filled-out
https://app.clubhouse.io/helpsupply/story/27/review-form-validation
https://app.clubhouse.io/helpsupply/story/151/mobile-not-able-to-bypass-additional-contact-person-forms
https://app.clubhouse.io/helpsupply/story/160/additional-info-field-during-grocery-flow-not-optional

* Setup validation and isRequired correctly on each page.
* When conditionally rendering in React, InputText and InputDropdown weren't calling `register` from `react-hook-form`. An example of this is the contact form on http://localhost:3000/service/grocery/location/Jb0LTFNxnp5mAavJI0q2 
  * Solution was to wrap those components in react-hook-form's `Controller` component, which handles loading and unloading. It expects a `defaultValue` props for setting initial value, and then `value` is still used for handling state, so slightly repetatative now, for now.


![Large GIF (374x808)](https://user-images.githubusercontent.com/1128500/79545170-19aba700-8045-11ea-843e-6c874add1b1d.gif)
