### PR TITLE
fix: wire-up childcare and petcare repeating fields

### DIFF
--- a/src/components/AdditionalFormTitle/AdditionalFormTitle.js
+++ b/src/components/AdditionalFormTitle/AdditionalFormTitle.js
@@ -30,7 +30,7 @@ AdditionalFormTitle.BottomRule = () => <div css={styles.bottomRule} />;
 AdditionalFormTitle.propTypes = {
   description: PropTypes.string,
   noBorder: PropTypes.bool,
-  secondaryCta: PropTypes.object,
+  secondaryCta: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
   title: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
* The repeating fields on pages like `http://localhost:3000/service/childcare/details/RlH99jLBAP9WEP5jf7js` needed some TLC to get wired up.

![localhost_3000_service_childcare_details_RlH99jLBAP9WEP5jf7js](https://user-images.githubusercontent.com/1128500/79621210-60da7c00-80c7-11ea-81d8-bfcc3e440444.png)
