### PR TITLE
feat: servicerequest status set to open when submitting

### DIFF
--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -23,8 +23,10 @@ export const Routes = {
   SUPPLY_NEW_ADMIN_CONFIRMATION: `/new/admin/supply/:id/confirmation/:requestId`,
 
   // MVP Routes
+  SERVICE_LOCATION: '/service-location',
+  SERVICE_LOCATION_AVAILABLE: '/service-location/available',
+  SERVICE_LOCATION_UNAVAILABLE: '/service-location/unavailable',
   FACILITY: `/facility`,
-  DASHBOARD: '/dashboard',
   EMAIL_SIGNUP_FORM: `/signup`,
   EMAIL_SIGNUP_SENT: `/signup/confirm`,
   // Update firebaseBackend.js if you change this (it can't require this, because
@@ -32,9 +34,6 @@ export const Routes = {
   EMAIL_SIGNUP_COMPLETE: `/signup/complete`,
   CONTACT_FORM: `/contact`,
   CONTACT_CONFIRMATION: `/contact/confirm`,
-  SERVICE_LOCATION: '/service-location',
-  SERVICE_LOCATION_AVAILABLE: '/service-location/available',
-  SERVICE_LOCATION_UNAVAILABLE: '/service-location/unavailable',
   SERVICE_TYPE: '/service',
   SERVICE_GROCERIES_WHERE: '/service/grocery/location/:id',
   SERVICE_GROCERIES_WHEN: '/service/grocery/date/:id',
@@ -51,6 +50,7 @@ export const Routes = {
   SERVICE_ADDITIONAL_INFO: '/service/additionalinfo/:id',
   SERVICE_REVIEW: '/service/review/:id',
   SERVICE_CONFIRMATION: '/service/confirmation/:id',
+  DASHBOARD: '/dashboard',
 
   // Admin and Debugging routes
   DEBUG_REQUESTS: '/requests/debug',

--- a/src/containers/ServiceReview.js
+++ b/src/containers/ServiceReview.js
@@ -18,16 +18,24 @@ import MentalHealthServiceReview from 'components/ServiceReview/MentalHealth';
 
 import { styles } from 'components/ServiceReview/ServiceReview.styles';
 
-function ServiceReview({ id, service }) {
+function ServiceReview({ backend, id, service }) {
   const history = useHistory();
   const { t } = useTranslation();
 
-  const handleSubmit = () => {
-    history.push(
-      routeWithParams(Routes.SERVICE_CONFIRMATION, {
-        id,
-      }),
-    );
+  const handleSubmit = async () => {
+    await backend
+      .updateServiceRequest(id, { status: 'open' }, true)
+      .then(() => {
+        history.push(
+          routeWithParams(Routes.SERVICE_CONFIRMATION, {
+            id,
+          }),
+        );
+      })
+      .catch((error) => {
+        console.error('error', error);
+      });
+    // service TODO: handle exceptions
   };
 
   return (

--- a/src/lib/utils/services.js
+++ b/src/lib/utils/services.js
@@ -2,7 +2,10 @@ import RequestKinds from 'lib/organizations/kinds';
 import { SERVICE_TEXT } from 'lib/constants/services';
 
 export const buildServicesOptions = () => {
-  return Object.entries(RequestKinds).map(([k, v], i) => {
+  const target = Object.entries(RequestKinds).map(([k, v], i) => {
     return { label: SERVICE_TEXT[i], value: v };
   });
+
+  // hiding petcare option from dropdown until a petcare organization is found
+  return target.filter((option) => option.value !== RequestKinds.PETCARE);
 };


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/233/set-revicerequest-status-to-open-when-submitting-on-the-review-submit-page

* Slightly rearranged routes file to mimic our current flow logic.
* Wired up a `updateServiceRequest` to `ServiceReview` page to set `status: open` on a `servicerequest` record.
* Remove petcare from serviceOptions dropdown.