### PR TITLE
feat: integrate zips

### DIFF
--- a/src/components/ServicesList/index.js
+++ b/src/components/ServicesList/index.js
@@ -3,6 +3,8 @@ import { Fragment } from 'react';
 import { jsx } from '@emotion/core';
 import { useTranslation } from 'react-i18next';
 
+import RequestKinds from 'lib/organizations/kinds';
+
 import Text from 'components/Text';
 import { TEXT_TYPE } from 'components/Text/constants';
 
@@ -46,7 +48,7 @@ const EmotionalSupport = () => {
   );
 };
 
-export const ServicesList = () => {
+export const ServicesList = ({ services }) => {
   const { t } = useTranslation();
 
   return (
@@ -54,10 +56,17 @@ export const ServicesList = () => {
       <Text as="h2" type={TEXT_TYPE.HEADER_3} css={styles.title}>
         {t('service.available.title')}
       </Text>
-      {/* service todo: only display services that are available */}
-      <Groceries />
-      <Childcare />
-      <EmotionalSupport />
+      {services?.map((svc) => {
+        if (svc[0] === RequestKinds.GROCERY) {
+          return <Groceries key={RequestKinds.GROCERY} />;
+        }
+        if (svc[0] === RequestKinds.CHILDCARE) {
+          return <Childcare key={RequestKinds.CHILDCARE} />;
+        }
+        if (svc[0] === RequestKinds.MENTALHEALTH) {
+          return <EmotionalSupport key={RequestKinds.MENTALHEALTH} />;
+        }
+      })}
     </Fragment>
   );
 };

--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -23,7 +23,7 @@ export const Routes = {
 
   // MVP Routes
   SERVICE_LOCATION: '/service-location',
-  SERVICE_LOCATION_AVAILABLE: '/service-location/available',
+  SERVICE_LOCATION_AVAILABLE: '/service-location/available/:zip?',
   SERVICE_LOCATION_UNAVAILABLE: '/service-location/unavailable',
   FACILITY: `/facility`,
   LOGIN: '/login',
@@ -31,7 +31,7 @@ export const Routes = {
   EMAIL_SIGNUP_SENT: `/signup/confirm`,
   // Update firebaseBackend.js if you change this (it can't require this, because
   // this file is outside of the lib package).
-  EMAIL_SIGNUP_COMPLETE: `/signup/complete`,
+  EMAIL_SIGNUP_COMPLETE: `/signup/complete/:zip?`,
   CONTACT_FORM: `/contact`,
   CONTACT_CONFIRMATION: `/contact/confirm`,
   SERVICE_TYPE: '/service',

--- a/src/containers/AvailableServices.js
+++ b/src/containers/AvailableServices.js
@@ -1,18 +1,45 @@
 /** @jsx jsx */
-import { Fragment } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { jsx } from '@emotion/core';
-import { useHistory } from 'react-router-dom';
+import { useHistory, useParams } from 'react-router-dom';
+
+import { Routes } from 'constants/Routes';
+import { isValidZipCode } from 'lib/utils/validations';
 
 import Text from 'components/Text';
 import { PrimaryButton } from 'components/Button';
 import ServicesList from 'components/ServicesList';
 
-import { Routes } from 'constants/Routes';
-
-function AvailableServices() {
+function AvailableServices({ backend }) {
   const history = useHistory();
+  const params = useParams();
   const { t } = useTranslation();
+  const [services, setServices] = useState();
+
+  const { zip: zipRulParam } = params;
+
+  useEffect(() => {
+    const zip = zipRulParam || backend.getLocalZip();
+
+    // if no zip in url and none in localstorage, go to enter your zip form
+    if ((!zipRulParam && !backend.getLocalZip()) || !isValidZipCode(zip)) {
+      history.push(Routes.SERVICE_LOCATION);
+      return;
+    }
+
+    const servicesByZip = backend.getServicesForZip(zip);
+
+    // if they somehow get here and there's not services for their zip, send them to unavailable page
+    if (!servicesByZip?.length) {
+      history.push(Routes.SERVICE_LOCATION_UNAVAILABLE);
+      return;
+    }
+
+    // if results for zip provided via localstorage or via url param, explicitly store the zip that works
+    backend.setLocalZip(zip);
+    setServices(servicesByZip);
+  }, [backend, history, setServices, zipRulParam]);
 
   const handleSubmit = () => {
     history.push(Routes.FACILITY);
@@ -20,7 +47,7 @@ function AvailableServices() {
 
   return (
     <Fragment>
-      <ServicesList />
+      <ServicesList services={services} />
       <PrimaryButton type="submit" onClick={handleSubmit}>
         <Text>{t('global.form.submitLabelNext')}</Text>
       </PrimaryButton>

--- a/src/containers/ServiceContactForm.js
+++ b/src/containers/ServiceContactForm.js
@@ -49,9 +49,11 @@ function ServiceContactForm({ backend, serviceUser }) {
   const { phone, ...requiredFields } = fields;
 
   const handleSubmit = (data) => {
+    const zip = serviceUser?.data?.zip || backend.getLocalZip();
     setIsLoading(true);
+
     backend
-      .saveServiceUser(data)
+      .saveServiceUser({ ...data, zip })
       .then(() => {
         setIsLoading(false);
         history.push(routeWithParams(Routes.CONTACT_CONFIRMATION));

--- a/src/containers/ServiceLocationForm.js
+++ b/src/containers/ServiceLocationForm.js
@@ -42,11 +42,21 @@ function ServiceLocationForm({ backend, serviceUser }) {
   const { zipCode, ...requiredFields } = fields;
 
   const handleSubmit = () => {
-    // service todo: save zip code field to local storage
     setIsLoading(true);
-    // service todo: check valid service types
-    history.push(routeWithParams(Routes.SERVICE_LOCATION_AVAILABLE));
-    // service todo: route to SERVICE_LOCATION_UNAVAILABLE if no services are valid
+
+    const servicesByZip = backend.getServicesForZip(fields.zipCode);
+
+    if (!servicesByZip?.length) {
+      history.push(routeWithParams(Routes.SERVICE_LOCATION_UNAVAILABLE));
+      return;
+    }
+
+    backend.setLocalZip(fields.zipCode);
+    history.push(
+      routeWithParams(Routes.SERVICE_LOCATION_AVAILABLE, {
+        zip: fields.zipCode,
+      }),
+    );
   };
 
   const fieldData = [

--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -51,6 +51,18 @@ export default class FirebaseBackend {
     }
   }
 
+  setLocalZip(zipCode) {
+    window.localStorage.setItem('zipCode', zipCode);
+  }
+
+  getLocalZip() {
+    return window.localStorage.getItem('zipCode');
+  }
+
+  clearLocalZip() {
+    return window.localStorage.removeItem('zipCode');
+  }
+
   // Returns an array of pairs [RequestKind, OrganizationId]
   getServicesForZip(zipCode) {
     return OrganizationIndex.ByZip[zipCode];
@@ -616,10 +628,10 @@ export default class FirebaseBackend {
     window.localStorage.setItem('emailForSignIn', email);
   }
 
-  async signupServicesWithEmail(email) {
+  async signupServicesWithEmail(email, zip) {
     const actionCodeSettings = {
       // Equal to EMAIL_SIGNUP_COMPLETE
-      url: `${window.location.protocol}//${window.location.host}/signup/complete/`,
+      url: `${window.location.protocol}//${window.location.host}/signup/complete/${zip}/`,
       handleCodeInApp: true,
     };
 

--- a/src/lib/utils/routes.js
+++ b/src/lib/utils/routes.js
@@ -3,7 +3,7 @@ export const routeWithParams = (route, params) => {
 
   const newRouteArray = routeSections.map((routeSection) => {
     if (routeSection.startsWith(':')) {
-      const routeParam = routeSection.split(':')[1];
+      const routeParam = routeSection.split(':')[1].replace('?', '');
       const matchedParam = params[routeParam];
 
       if (!matchedParam) {


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/227/save-zip-code-value-to-user-and-request
https://app.clubhouse.io/helpsupply/story/247/zip-code-qualification-form-integration

* On the `SERVICE_LOCATION` page, hooked up `getServicesForZip`.
  * If no services available, redirect to 'no results for zip' page.
  * If services available, store the zip and redirect to 'zip results' aka (`SERVICE_LOCATION_AVAILABLE`) page.
* Only show relevant services on the 'zip results' page.
* Zip results page accepts a zip in the url as well as localStorage, redirects you out of there if either zip is neither present nor valid.
* Zip data get passed over to the email signup/login link.
* Zip data persists until the `/contact` page, where it finally get stored to the user.