### PR TITLE
Non supported zip code flow setup

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -35,6 +35,8 @@ import Contact from 'pages/contact';
 import ContactConfirmation from 'pages/contact_confirmation';
 import ServiceLocation from 'pages/service_location';
 import ServiceLocationAvailable from 'pages/service_location_available';
+import ServiceLocationUnavailable from 'pages/service_location_unavailable';
+import EmailListConfirmation from 'pages/email_list_confirmation';
 import ServiceType from 'pages/service_type';
 import ServiceGrocery from 'pages/service_grocery';
 import ServiceChildcare from 'pages/service_childcare';
@@ -140,6 +142,16 @@ function App({ backend }) {
                 path={Routes.SERVICE_LOCATION_AVAILABLE}
               >
                 <ServiceLocationAvailable backend={backend} />
+              </Route>
+              <Route
+                backend={backend}
+                exact
+                path={Routes.SERVICE_LOCATION_UNAVAILABLE}
+              >
+                <ServiceLocationUnavailable backend={backend} />
+              </Route>
+              <Route backend={backend} exact path={Routes.EMAIL_LIST_SENT}>
+                <EmailListConfirmation backend={backend} />
               </Route>
               <Route exact path={Routes.FACILITY}>
                 <Facility backend={backend} />

--- a/src/components/Confirmation/ConfirmationWrapper.js
+++ b/src/components/Confirmation/ConfirmationWrapper.js
@@ -7,13 +7,13 @@ import { ReactComponent as Check } from 'static/icons/green-check.svg';
 
 import styles from './Confirmation.styles.js';
 
-function ConfirmationWrapper({ children, title }) {
+function ConfirmationWrapper({ children, title, noIcon }) {
   return (
     <div css={styles.root}>
       <div css={[styles.header, styles.section]}>
         <Text as="h3" type={TEXT_TYPE.HEADER_3} css={styles.title}>
           {title}
-          <Check css={styles.check} />
+          {!noIcon && <Check css={styles.check} />}
         </Text>
       </div>
       {children}

--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -25,6 +25,7 @@ export const Routes = {
   SERVICE_LOCATION: '/service-location',
   SERVICE_LOCATION_AVAILABLE: '/service-location/available/:zip?',
   SERVICE_LOCATION_UNAVAILABLE: '/service-location/unavailable',
+  EMAIL_LIST_SENT: '/service-location/unavailable/confirm',
   FACILITY: `/facility`,
   LOGIN: '/login',
   EMAIL_SIGNUP_FORM: `/signup`,

--- a/src/containers/EmailListForm.js
+++ b/src/containers/EmailListForm.js
@@ -1,0 +1,52 @@
+/** @jsx jsx */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { jsx } from '@emotion/core';
+import { useHistory } from 'react-router-dom';
+
+import { Routes } from 'constants/Routes';
+import { isValidEmail } from 'lib/utils/validations';
+
+import FormBuilder from 'components/Form/FormBuilder';
+import { formFieldTypes } from 'components/Form/CreateFormFields';
+
+function EmailListForm() {
+  const history = useHistory();
+  const { t } = useTranslation();
+
+  const [email, setEmail] = useState('');
+
+  const validate = (val) => {
+    if (!isValidEmail(val)) {
+      return t('request.workEmailForm.workEmail.validationLabel');
+    }
+  };
+
+  const handleSubmit = () => {
+    history.push(Routes.EMAIL_LIST_SENT);
+  };
+
+  const fieldData = [
+    {
+      customOnChange: setEmail,
+      label: t('global.form.emailAddressLabel'),
+      name: 'email',
+      type: formFieldTypes.INPUT_TEXT,
+      validation: { validate },
+    },
+  ];
+
+  return (
+    <FormBuilder
+      defaultValues={{ email: '' }}
+      onSubmit={handleSubmit}
+      title={t('service.unavailable.title')}
+      description={t('service.unavailable.description')}
+      disabled={!isValidEmail(email)}
+      fields={fieldData}
+      buttonLabel={t('global.form.submitLabel')}
+    />
+  );
+}
+
+export default EmailListForm;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,6 +12,7 @@
         "deleteLabel": "Delete",
         "submitLabelCta": "Please complete form",
         "submitLabelNext": "Next",
+        "emailAddressLabel": "Email address",
         "daypicker": {
           "placeholder": "Date needed"
         }
@@ -263,6 +264,14 @@
           "mutualAid": "Provided by Mutual Aid NYC",
           "workersNeedChildcare": "Provided by Workers Need Childcare",
           "nycCovid": "Provided by NYC COVID Care Network"
+        }
+      },
+      "unavailable": {
+        "title": "Sorry, we're not able to offer services in your area yet",
+        "description": "Please enter your email address if you'd like us to reach out when we expand to more locations.",
+        "sent": {
+          "title": "Thank you",
+          "description": "We'll let you know when we expand to more locations."
         }
       },
       "contactForm": {

--- a/src/pages/email_list_confirmation.js
+++ b/src/pages/email_list_confirmation.js
@@ -1,0 +1,24 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+import { useTranslation } from 'react-i18next';
+
+import Page from 'components/layouts/Page';
+import ConfirmationWrapper from 'components/Confirmation/ConfirmationWrapper';
+import Text from 'components/Text';
+import { TEXT_TYPE } from 'components/Text/constants';
+
+function EmailListConfirmation() {
+  const { t } = useTranslation();
+
+  return (
+    <Page>
+      <ConfirmationWrapper noIcon title={t('service.unavailable.sent.title')}>
+        <Text as="p" type={TEXT_TYPE.BODY_2}>
+          {t('service.unavailable.sent.description')}
+        </Text>
+      </ConfirmationWrapper>
+    </Page>
+  );
+}
+
+export default EmailListConfirmation;

--- a/src/pages/service_location_unavailable.js
+++ b/src/pages/service_location_unavailable.js
@@ -1,0 +1,15 @@
+/** @jsx jsx */
+import { jsx } from '@emotion/core';
+
+import EmailListForm from 'containers/EmailListForm';
+import Page from 'components/layouts/Page';
+
+function ServiceLocationUnavailable({ backend }) {
+  return (
+    <Page>
+      <EmailListForm backend={backend} />
+    </Page>
+  );
+}
+
+export default ServiceLocationUnavailable;


### PR DESCRIPTION
- if zip code entered is not valid, send user to unavailable page w/ email list sign up
- upon submitting email list sign up, route user to a confirmation page for the email list
- add `noIcon` prop to confirmation wrapper

![Screen Shot 2020-04-18 at 7 35 18 PM](https://user-images.githubusercontent.com/11987517/79678023-e0417b80-81ab-11ea-9515-65c48a31b1b5.png)