### PR TITLE
Update data on service confirmation page

### DIFF
--- a/src/components/Confirmation/OrganizationConfirmation.js
+++ b/src/components/Confirmation/OrganizationConfirmation.js
@@ -19,11 +19,13 @@ export const OrganizationConfirmation = ({ organization }) => {
       <Text as="p" css={styles.organizationName}>
         {organization.name}
       </Text>
-      <Text as="p" type={TEXT_TYPE.NOTE}>
-        <Anchor href={`mailto:${organization.email}`} as={anchorTypes.A}>
-          {organization.email}
-        </Anchor>
-      </Text>
+      {organization.email && (
+        <Text as="p" type={TEXT_TYPE.NOTE}>
+          <Anchor href={`mailto:${organization.email}`} as={anchorTypes.A}>
+            {organization.email}
+          </Anchor>
+        </Text>
+      )}
       <Text as="p" type={TEXT_TYPE.NOTE}>
         <Anchor
           href={`http://${organization.website}`}

--- a/src/components/Confirmation/ServiceConfirmation.js
+++ b/src/components/Confirmation/ServiceConfirmation.js
@@ -33,8 +33,16 @@ export const ServiceConfirmation = ({ service }) => {
     [RequestKinds.CHILDCARE]: [OrganizationDetails.WORKERS_NEED_CHILDCARE],
   });
 
+  const mapServiceToName = () => ({
+    [RequestKinds.GROCERY]: 'groceries',
+    [RequestKinds.MENTALHEALTH]: 'emotional support',
+    [RequestKinds.CHILDCARE]: 'childcare',
+  });
+
   const organization = mapServiceToOrganization()[kind][0];
   const organizationName = organization.name;
+
+  const serviceName = mapServiceToName()[kind];
 
   const handleViewRequests = () => {
     history.push(Routes.DASHBOARD);
@@ -68,7 +76,7 @@ export const ServiceConfirmation = ({ service }) => {
 
   return (
     <ConfirmationWrapper
-      title={t('request.serviceConfirmation.title', { kind })}
+      title={t('request.serviceConfirmation.title', { serviceName })}
     >
       <Text as="p" type={TEXT_TYPE.BODY_2} css={styles.description}>
         {t('request.serviceConfirmation.description', { organizationName })}

--- a/src/lib/organizations/details.js
+++ b/src/lib/organizations/details.js
@@ -3,18 +3,17 @@
 export const OrganizationDetails = {
   MUTUAL_AID_NYC: {
     name: 'Mutual Aid NYC',
-    website: 'https://mutualaid.nyc/',
-    email: 'email@mutualaid.com',
+    website: 'mutualaid.nyc',
   },
   WORKERS_NEED_CHILDCARE: {
     name: 'Workers Need Childcare',
-    website: 'https://www.workersneedchildcare.org/',
-    email: 'email@workersneedchildcare.com',
+    website: 'www.workersneedchildcare.org',
+    email: 'hello@workersneedchildcare.org',
   },
   NYC_COVID_CARE_NETWORK: {
     name: 'NYC COVID Care Network',
-    website: 'https://www.nyccovidcare.org/',
-    email: 'email@nyccovidcare.com',
+    website: 'www.nyccovidcare.org',
+    email: 'nyccovidcare@gmail.com',
   },
 };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -170,7 +170,7 @@
         }
       },
       "serviceConfirmation": {
-        "title": "We have your request for {{kind}}",
+        "title": "We have your request for {{serviceName}}",
         "description": "Your request has been routed to {{organizationName}}. They will contact you to fulfill your request.",
         "requestServices": "Request more services",
         "viewRequests": "View my requests",


### PR DESCRIPTION
- add organization emails + adjust website data
- check for email before displaying that field (manyc doesn't have a support email)
- add map service to name that fixes the display of the service name

![Screen Shot 2020-04-18 at 7 53 28 PM](https://user-images.githubusercontent.com/11987517/79678261-4d561080-81ae-11ea-8126-7eb1143f152c.png)