### PR TITLE
fix: dropdown values for repeating fields have duplicate name values

### DIFF
--- a/src/components/InputDropdown/index.js
+++ b/src/components/InputDropdown/index.js
@@ -13,6 +13,7 @@ import styles from './InputDropdown.styles';
 const DEFAULT = 'placeholder';
 
 function InputDropdown({
+  customkey,
   customOnChange,
   defaultValue,
   inputProps,
@@ -66,7 +67,7 @@ function InputDropdown({
           </select>
         }
         defaultValue={defaultValue ? defaultValue : DEFAULT}
-        name={name}
+        name={customkey ? customkey : name}
         onChange={(args) => handleChange(args[0].nativeEvent)}
         rules={{
           ...validation,


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/273/pet-care-childcare-editing-pet-or-child-2-3-etc-details-changes-the-first-pet-in-the-list

* Changing a dropdown value for something like `Child 2` or `Child 3` was updating the displayed value for child 1 because of duplicate name value. Solution it to use `customkey`.

