### PR TITLE
Layout fix

### DIFF
--- a/src/components/InputDate/InputDate.js
+++ b/src/components/InputDate/InputDate.js
@@ -22,15 +22,16 @@ function InputDate({ label, customOnChange, defaultValue }) {
 
   const handleDayChange = useCallback(
     (selectedDay) => {
+      const day = moment(selectedDay).format('MMMM D, YYYY');
       if (customOnChange) {
-        customOnChange(selectedDay);
+        customOnChange(day);
       }
 
-      if (!selectedDay) {
+      if (!day) {
         setValue('');
         return;
       }
-      setValue(selectedDay);
+      setValue(day);
     },
     [customOnChange],
   );
@@ -50,6 +51,7 @@ function InputDate({ label, customOnChange, defaultValue }) {
       )}
 
       <DayPickerInput
+        inputProps={{ readOnly: true }}
         ref={dayPicker}
         format="MMMM Do, YYYY"
         formatDate={formatDate}

--- a/src/index.css
+++ b/src/index.css
@@ -4,7 +4,17 @@ html,
 body,
 #root,
 .App {
-  height: 100%;
+  min-height: 100%;
+}
+
+/* large breakpoint */
+@media screen and (min-width: 900px) {
+  html,
+  body,
+  #root,
+  .App {
+    height: 100%;
+  }
 }
 
 body {


### PR DESCRIPTION
for some reason height: 100% doesn't work on ios so we need to set it to min-height to correctly span the content.

i'm not sure if this is related to the other mobile layout bugs yet

height: 100%:
<img width="419" alt="Screen Shot 2020-04-19 at 2 40 32 PM" src="https://user-images.githubusercontent.com/19784034/79700629-f0a93300-824b-11ea-8353-aa60605d4fcc.png">

min-height: 100%
<img width="412" alt="Screen Shot 2020-04-19 at 2 42 19 PM" src="https://user-images.githubusercontent.com/19784034/79700639-0ae31100-824c-11ea-9d57-62875a6460f1.png">

