### PR TITLE
fix: pass backend prop to login page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -139,7 +139,7 @@ function App({ backend }) {
                   <ServiceLocation backend={backend} />
                 </Route>
                 <Route path={Routes.LOGIN}>
-                  <Login />
+                  <Login backend={backend} />
                 </Route>
                 <Route
                   backend={backend}


### PR DESCRIPTION
Just noticed the `backend` prop was missing on the `Login` page.