### PR TITLE
fix: child email confirmation data, email organization name

### DIFF
--- a/src/containers/ServiceReview.js
+++ b/src/containers/ServiceReview.js
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { Routes } from 'constants/Routes';
 import { mentalHealthOptions } from 'lib/constants/options';
 import { routeWithParams } from 'lib/utils/routes';
+import { formatDate } from 'lib/utils/datetime';
 import RequestKinds from 'lib/organizations/kinds';
 import { mapServiceKindToTitle } from 'lib/theme/services';
 
@@ -19,6 +20,19 @@ import PetcareServiceReview from 'components/ServiceReview/Petcare';
 import MentalHealthServiceReview from 'components/ServiceReview/MentalHealth';
 
 import { styles } from 'components/ServiceReview/ServiceReview.styles';
+
+const buildChildcareDate = (service) => {
+  return [
+    service.mondays && 'Mondays',
+    service.tuesdays && 'Tuesdays',
+    service.wednesdays && 'Wednesdays',
+    service.thursdays && 'Thursdays',
+    service.fridays && 'Fridays',
+    service.saturdays && 'Saturdays',
+    service.sundays && 'Sundays',
+    service.varies && 'Days vary',
+  ].filter((day) => !!day);
+};
 
 function ServiceReview({ backend, id, service, serviceUser, user }) {
   const history = useHistory();
@@ -34,7 +48,7 @@ function ServiceReview({ backend, id, service, serviceUser, user }) {
           organization: backend.getMetadataForProvider(service.organization)
             .Organization,
           type: mapServiceKindToTitle()[service.kind],
-          date: service.date,
+          date: service.date ? service.date : formatDate(service.timeCreated),
           details,
         }),
       )
@@ -88,7 +102,6 @@ function ServiceReview({ backend, id, service, serviceUser, user }) {
 
     setDetails({
       ...contact,
-      ...(service.date && { Date: `${service.date}, ${service.time}` }),
 
       // groceries
       ...(service.groceryList && { 'Grocery List': service.groceryList }),
@@ -104,8 +117,11 @@ function ServiceReview({ backend, id, service, serviceUser, user }) {
         }),
 
       // childcare
+      ...(buildChildcareDate(service)[0] && {
+        'Preferred Day': buildChildcareDate(service)[0],
+      }),
       ...(service.children && {
-        Children: Object.keys(service.children).length,
+        Children: Object.keys(service.children).length.toString(),
       }),
 
       ...(service.additionalInfo && {

--- a/src/containers/ServiceReview.js
+++ b/src/containers/ServiceReview.js
@@ -31,7 +31,8 @@ function ServiceReview({ backend, id, service, serviceUser, user }) {
       .then(() =>
         backend.sendRequestConfirmation({
           id,
-          organization: service.organization,
+          organization: backend.getMetadataForProvider(service.organization)
+            .Organization,
           type: mapServiceKindToTitle()[service.kind],
           date: service.date,
           details,


### PR DESCRIPTION
* Use pretty name for organization data in email.
* Use timeCreated for childcare forms where Date isn't specified.
* Cast number of children to String so detail formatting doesn't break.
* Add 'Preferred days' to childcare details.
