### PR TITLE
fix: delivery date format

### DIFF
--- a/src/components/ServiceReview/Grocery.js
+++ b/src/components/ServiceReview/Grocery.js
@@ -35,7 +35,7 @@ export const GroceryServiceReview = ({ id, service }) => {
     time,
   } = service;
 
-  const formattedDate = formatServiceDate(new Date(date));
+  const formattedDate = formatServiceDate(date);
 
   const handleRedirectIntent = () => {
     const url = routeWithParams(Routes.SERVICE_REVIEW, { id });

--- a/src/lib/utils/datetime.js
+++ b/src/lib/utils/datetime.js
@@ -9,5 +9,5 @@ export const formatDate = (date) => {
 // Format service date
 export const formatServiceDate = (date) => {
   const momentDate = date ? moment(new Date(date)) : moment();
-  return momentDate.format('dddd MMMM wo');
+  return momentDate.format('dddd MMMM Do');
 };


### PR DESCRIPTION
* Date format was returning the week of the year (i.e. the 52nd for last week of year) rather than the day of the month (i.e. 1st, 2nd, etc.)