### PR TITLE
Fix Login & Signup

### DIFF
--- a/src/constants/Routes.js
+++ b/src/constants/Routes.js
@@ -35,7 +35,7 @@ export const Routes = {
   EMAIL_SIGNUP_SENT: `/signup/confirm`,
   // Update firebaseBackend.js if you change this (it can't require this, because
   // this file is outside of the lib package).
-  EMAIL_SIGNUP_COMPLETE: `/signup/complete/:zip?`,
+  EMAIL_SIGNUP_COMPLETE: `/signup/complete/:zip?/:facility?`,
   CONTACT_FORM: `/contact`,
   CONTACT_CONFIRMATION: `/contact/confirm`,
   SERVICE_TYPE: '/service',

--- a/src/containers/EmailForm.js
+++ b/src/containers/EmailForm.js
@@ -49,7 +49,11 @@ function EmailForm({ backend }) {
     }
 
     backend
-      .signupServicesWithEmail(email, backend.getLocalZip())
+      .signupServicesWithEmail(
+        email,
+        backend.getLocalZip(),
+        backend.getLocalFacility(),
+      )
       .then(() => {
         history.push(routeWithParams(Routes.EMAIL_SIGNUP_SENT));
       })

--- a/src/containers/FacilityForm.js
+++ b/src/containers/FacilityForm.js
@@ -97,6 +97,9 @@ function FindFacility({ backend }) {
 
     setIsLoading(true);
 
+    // Stash this for later
+    backend.setLocalFacility(selectedResult);
+
     // service todo: incorporate facility data below, and decide what validation or state management happens here
     // const facility = hospital_index.index.id_index[selectedResult];
     history.push(routeWithParams(Routes.EMAIL_SIGNUP_FORM));

--- a/src/containers/ServiceContactForm.js
+++ b/src/containers/ServiceContactForm.js
@@ -49,11 +49,12 @@ function ServiceContactForm({ backend, serviceUser }) {
   const { phone, ...requiredFields } = fields;
 
   const handleSubmit = (data) => {
-    const zip = serviceUser?.data?.zip || backend.getLocalZip();
+    const zip = backend.getLocalZip();
+    const facility = backend.getLocalFacility();
     setIsLoading(true);
 
     backend
-      .saveServiceUser({ ...data, zip })
+      .saveServiceUser({ ...data, zip, facility })
       .then(() => {
         setIsLoading(false);
         history.push(routeWithParams(Routes.CONTACT_CONFIRMATION));

--- a/src/lib/firebaseBackend.js
+++ b/src/lib/firebaseBackend.js
@@ -70,6 +70,14 @@ export default class FirebaseBackend {
     return window.localStorage.removeItem('zipCode');
   }
 
+  setLocalFacility(facility) {
+    window.localStorage.setItem('facility', facility);
+  }
+
+  getLocalFacility(facility) {
+    return window.localStorage.getItem('facility');
+  }
+
   // Returns an array of pairs [RequestKind, OrganizationId]
   getServicesForZip(zipCode) {
     return OrganizationIndex.ByZip[zipCode];
@@ -644,7 +652,7 @@ export default class FirebaseBackend {
     window.localStorage.setItem('emailForSignIn', email);
   }
 
-  async signupServicesWithEmail(email, zip) {
+  async signupServicesWithEmail(email, zip, facility) {
     window.localStorage.setItem('emailForSignIn', email);
     await axios({
       method: 'POST',
@@ -652,7 +660,7 @@ export default class FirebaseBackend {
       url: functionurl + '/sendSigninEmail',
       params: {
         email: email,
-        url: `${window.location.protocol}//${window.location.host}/signup/complete/${zip}/`,
+        url: `${window.location.protocol}//${window.location.host}/signup/complete/${zip}/${facility}`,
       },
     });
   }


### PR DESCRIPTION
A bunch of changes rolled into one:

- Returning login redirects directly to the dashboard (thinks to myself, do we need to do the email check again?)
- We now save the facility information similarly to how we store zip in localstorage and serviceuser
- The welcome page is now part of the sign up page