### PR TITLE
fix: checkbox bottom margin

### DIFF
--- a/src/components/Checkbox/Checkbox.styles.js
+++ b/src/components/Checkbox/Checkbox.styles.js
@@ -13,6 +13,7 @@ const styles = {
     color: Color.GRAY_75,
     cursor: 'pointer',
     display: 'flex',
+    marginBottom: Space.S25,
     userSelect: 'none',
     width: '100%',
   }),


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/477/design-qa-childcare-form-content-order-spacing

* Added 25px margin-bottom to checkboxes. Verified this fix works on other instances of the checkbox.