### PR TITLE
fix: add spacing on childcare options learnmore component

### DIFF
--- a/src/containers/ChildcareFormOptions.js
+++ b/src/containers/ChildcareFormOptions.js
@@ -7,7 +7,7 @@ import ReactMarkdown from 'react-markdown';
 
 import { Routes } from 'constants/Routes';
 import { routeWithParams } from 'lib/utils/routes';
-import { Color } from 'lib/theme';
+import { Color, Space } from 'lib/theme';
 
 import Anchor, { anchorTypes } from 'components/Anchor';
 import Text from 'components/Text';
@@ -16,6 +16,8 @@ import { AdditionalFormTitle } from 'components/AdditionalFormTitle';
 import FormBuilder from 'components/Form/FormBuilder';
 import { formFieldTypes } from 'components/Form/CreateFormFields';
 import { StateContext } from 'state/StateProvider';
+
+const nodeContainerStyles = { color: Color.GRAY_75, marginBottom: Space.S30 };
 
 function ChildcareFormDetails({ id, onSave, request }) {
   const history = useHistory();
@@ -126,7 +128,7 @@ function ChildcareFormDetails({ id, onSave, request }) {
         <Text
           as="div"
           type={TEXT_TYPE.NOTE}
-          css={{ color: Color.GRAY_75 }}
+          css={nodeContainerStyles}
           key="childcare-options-note-1"
         >
           <ReactMarkdown


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/643/design-qa-childcare-options-covid-learn-more-link-spacing

* Add spacing below the 'learn more' node.

<img width="368" alt="Screenshot 2020-04-28 11 15 43" src="https://user-images.githubusercontent.com/1128500/80522710-dc4af180-8941-11ea-9cef-d3b2ca451ace.png">
