### PR TITLE
fix: desktop logo placement

### DIFF
--- a/src/components/Header/LargeHeader.js
+++ b/src/components/Header/LargeHeader.js
@@ -9,8 +9,8 @@ import { ReactComponent as Logo } from 'static/icons/logo.svg';
 
 import styles from './LargeHeader.styles';
 
-const LargeHeader = ({ isHome, hasBackButton }) => (
-  <div css={[styles.root, !isHome && hasBackButton && styles.marginTop]}>
+const LargeHeader = ({ hasBackButton }) => (
+  <div css={[styles.root, !hasBackButton && styles.alignTop]}>
     <Anchor href={Routes.HOME}>
       <Logo fill={Color.WHITE} />
     </Anchor>

--- a/src/components/Header/LargeHeader.styles.js
+++ b/src/components/Header/LargeHeader.styles.js
@@ -4,15 +4,15 @@ import { Color, Space } from 'lib/theme';
 const mobileMinHeight = '170px';
 
 const styles = {
+  alignTop: css({
+    alignSelf: 'flex-start',
+  }),
   root: css({
     alignItems: 'flex-end',
     backgroundColor: `${Color.PRIMARY}`,
     display: ['block', null, 'flex'],
     padding: [`${mobileMinHeight} ${Space.S40}px 0`, '', 0],
     width: '100%',
-  }),
-  marginTop: css({
-    marginTop: ['', '', '75%'],
   }),
 };
 

--- a/src/components/layouts/Page/Page.styles.js
+++ b/src/components/layouts/Page/Page.styles.js
@@ -32,9 +32,12 @@ const styles = {
     paddingTop: Space.S110,
   }),
   headerContentDesktop: css({
+    alignItems: 'flex-end',
+    display: ['block', null, 'flex'],
+    height: '100%',
     overflow: 'auto',
     position: 'relative',
-    padding: `${Space.S40}px ${rightPaddingDesktop}% ${Space.S40}px ${Space.S150}px`,
+    padding: `${Space.S40}px ${rightPaddingDesktop}% ${Space.S150}px ${Space.S150}px`,
   }),
   pageContent: css({
     display: 'flex',


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/681/design-qa-desktop-logo-placement

* Current desktop logo is '75%' percent from the top, which is all over the place.
  * This places the desktop logo at the 'end' of the container, 150px from the bottom.

![Large GIF (1374x720)](https://user-images.githubusercontent.com/1128500/80526121-21bded80-8947-11ea-86be-dca5a8134a1c.gif)
