### PR TITLE
feat: add dividing line to homepage

### DIFF
--- a/src/components/HomePage/HomePage.styles.js
+++ b/src/components/HomePage/HomePage.styles.js
@@ -1,5 +1,5 @@
 import { css } from 'lib/utils/media-queries';
-import { Color, Space } from 'lib/theme';
+import { Borders, Color, Space } from 'lib/theme';
 
 const styles = {
   homePageContainer: css({
@@ -18,6 +18,7 @@ const styles = {
     flexDirection: 'column',
   }),
   homePageContentLeft: css({
+    borderRight: Borders.WHITE,
     flexBasis: '50%',
     paddingRight: '14%',
   }),


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/444/design-qa-homepage-alignment-desktop

* Adding a dividing line down the center of the homepage.

<img width="1283" alt="Screenshot 2020-04-28 15 45 37" src="https://user-images.githubusercontent.com/1128500/80545088-5fcb0980-8967-11ea-88ec-8d40eac6850a.png">
