### PR TITLE
fix: add new note to thank you screen

### DIFF
--- a/src/components/Confirmation/ServiceConfirmation.styles.js
+++ b/src/components/Confirmation/ServiceConfirmation.styles.js
@@ -15,6 +15,7 @@ export const styles = {
   organization: css({
     background: Color.GRAY_10,
     borderRadius: Radius.ROUNDED,
+    overflowWrap: 'break-word',
     padding: Space.S25,
     marginBottom: Space.S40,
   }),

--- a/src/components/Confirmation/SignUpConfirmation.js
+++ b/src/components/Confirmation/SignUpConfirmation.js
@@ -21,6 +21,9 @@ export const SignUpConfirmation = ({ email }) => {
           })}
         />
       </Text>
+      <Text as="div" type={TEXT_TYPE.BODY_2} css={styles.description}>
+        {t('request.workEmailForm.sent.note')}
+      </Text>
     </ConfirmationWrapper>
   );
 };

--- a/src/components/Confirmation/SignUpConfirmation.styles.js
+++ b/src/components/Confirmation/SignUpConfirmation.styles.js
@@ -3,9 +3,12 @@ import { Color } from 'lib/theme';
 
 export const styles = {
   description: css({
+    color: Color.GRAY_75,
+
     strong: {
       color: Color.PRIMARY,
       fontWeight: 'normal',
+      textTransform: 'lowercase',
     },
   }),
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -277,7 +277,8 @@
         "sent": {
           "title": "Thank you",
           "description": "We just sent an email to {{email}}. Please follow the link in that email to start a new request.",
-          "emailDefault": "the email address you provided"
+          "emailDefault": "the email address you provided",
+          "note": "If you don’t receive this email, please check your spam/junk folder or submit your email again."
         },
         "finish": {
           "title": "Please enter your email, once more"


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/691/design-qa-thank-you-confirmation-type-styles-spacing-and-copy

* Verify fonts and colors for thank you signin page.
* Fix a word-break issue on service confirmation page.

<img width="440" alt="Screenshot 2020-04-29 12 37 04" src="https://user-images.githubusercontent.com/1128500/80639028-46cd6180-8a16-11ea-978c-52bd494a2db3.png">
