### PR TITLE
fix: page loader size

### DIFF
--- a/src/components/Loader/PageLoader.styles.js
+++ b/src/components/Loader/PageLoader.styles.js
@@ -6,6 +6,7 @@ const styles = {
     position: 'fixed',
     top: '50%',
     transform: 'translate3d(-50%, -50%, 0)',
+    width: ['82px', null, '130px'],
   }),
 };
 


### PR DESCRIPTION
https://app.clubhouse.io/helpsupply/story/738/design-qa-loading-animation-width

* Final sizes are different than what is requested in the ticket to accomodate lottie margins. See screencap demoing margins in lottie file.

![Large GIF (342x382)](https://user-images.githubusercontent.com/1128500/80640967-03c0bd80-8a19-11ea-98d2-611c372ebf34.gif)
