### PR TITLE
fix: hide share link if browser doesn't support sharing or clipboard functionality

### DIFF
--- a/src/components/Confirmation/ServiceConfirmation.js
+++ b/src/components/Confirmation/ServiceConfirmation.js
@@ -89,7 +89,7 @@ export const ServiceConfirmation = ({ service }) => {
             })}
       </Text>
       <OrganizationConfirmation organization={organization} />
-      {!isDesktop && (
+      {!isDesktop && (navigator.share || navigator.clipboard) && (
         <div css={styles.shareLink}>
           <LinkButton css={styles.link} onClick={handleShare}>
             <Text type={TEXT_TYPE.BODY_1}>


### PR DESCRIPTION
[ch616](https://app.clubhouse.io/helpsupply/story/616/fix-social-share-on-samsung-galaxy)

* Test for `navigator.share` or `navigator.clipboard` and hide if neither are present.