### PR TITLE
fix: childcare location dropdown

### DIFF
--- a/src/containers/ChildcareFormLocation.js
+++ b/src/containers/ChildcareFormLocation.js
@@ -41,7 +41,7 @@ function ChildcareFormLocation({ id, onSave, neighborhoodOptions }) {
   const [isLoading, setIsLoading] = useState(false);
   const [addAdditionalContact, setAddAdditionalContact] = useState();
   const [fields, setFields] = useState({
-    neighborhood: '',
+    neighborhood: undefined,
     crossStreet: '',
   });
 


### PR DESCRIPTION
[ch878](https://app.clubhouse.io/helpsupply/story/878/childcare-flow-neighborhood-selection-does-not-allow-for-first-option-unless-user-picks-another-then-goes-back)