### PR TITLE
fix: progressbar z-index, scroll-bounce

### DIFF
--- a/src/App.styles.js
+++ b/src/App.styles.js
@@ -1,4 +1,5 @@
 import { css } from '@emotion/core';
+import { Breakpoints } from 'lib/constants/breakpoints';
 
 export const styles = css`
   *,
@@ -29,12 +30,18 @@ export const styles = css`
     font-family: 'Inter', sans-serif;
     font-size: 1rem;
     margin: 0;
+    overflow: visible;
 
     @include font-size('1rem');
     font-weight: 400;
     line-height: 1.5;
     -webkit-text-size-adjust: 100%;
     -webkit-tap-highlight-color: rgba('#000', 0);
+  }
+  @media only screen and (min-width: ${Breakpoints.LARGE}px) {
+    body {
+      overflow: hidden;
+    }
   }
   svg {
     overflow: hidden;

--- a/src/components/Header/Header.styles.js
+++ b/src/components/Header/Header.styles.js
@@ -23,7 +23,6 @@ const styles = {
   progressBar: css({
     background: Color.PRIMARY,
     bottom: `-${bottomBorderSize}px`,
-    content: '""',
     display: 'block',
     height: `${bottomBorderSize}px`,
     left: 0,

--- a/src/components/layouts/Page/Page.styles.js
+++ b/src/components/layouts/Page/Page.styles.js
@@ -69,6 +69,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     height: '100%',
+    overflow: [null, null, 'scroll'],
   }),
   copyright: css({
     color: Color.WHITE_75,

--- a/src/components/layouts/Page/index.js
+++ b/src/components/layouts/Page/index.js
@@ -170,11 +170,6 @@ const Page = ({
               !isHome && styles.headerContainerDesktopInnerPage,
             ]}
           >
-            <ProgressBar
-              currentProgress={currentProgress}
-              isDesktop={isDesktop}
-              totalProgress={totalProgress}
-            />
             <div css={isDesktop && styles.headerContentDesktop} ref={headerRef}>
               {!isHome && hasBackButton && (
                 <BackButton onClick={onBackButtonClick} />
@@ -206,6 +201,13 @@ const Page = ({
           onBackButtonClick={onBackButtonClick}
           topPadding={pageContentTopPadding}
         />
+        {!willUseSmallHeader && (
+          <ProgressBar
+            currentProgress={currentProgress}
+            isDesktop={isDesktop}
+            totalProgress={totalProgress}
+          />
+        )}
       </div>
     </Fragment>
   );


### PR DESCRIPTION
* On desktop, the progress-bar was behind form elements. This PR moves the progress-bar farther down the html content stack, since z-index doesn't affect `position: fixed` in the this case.

![Large GIF (482x200)](https://user-images.githubusercontent.com/1128500/81589899-d0fabb80-936e-11ea-94ee-1bb38830b8c1.gif)


* Prevent scroll bounce on desktop because the progress-bar was jumping out in a visually strange way.

![Large GIF (482x200)](https://user-images.githubusercontent.com/1128500/81589907-d3f5ac00-936e-11ea-8c10-f0ad0bcdfa40.gif)
