### PR TITLE
fix: service confirmation button styles

### DIFF
--- a/src/components/Confirmation/ServiceConfirmation/ServiceConfirmation.styles.js
+++ b/src/components/Confirmation/ServiceConfirmation/ServiceConfirmation.styles.js
@@ -34,6 +34,7 @@ export const styles = {
     marginTop: Space.S15,
   }),
   secondaryButton: css({
+    borderRadius: Radius.ROUNDED,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',


### PR DESCRIPTION
* Button styles on the `/service/confirmation` screen were slightly different.

Different `border-radius` ↓
<img width="323" alt="Screenshot 2020-05-14 14 44 39" src="https://user-images.githubusercontent.com/1128500/81991351-e7667880-95f5-11ea-8cf2-9b926f35158a.png">

Fixed ↓
<img width="336" alt="Screenshot 2020-05-14 14 44 50" src="https://user-images.githubusercontent.com/1128500/81991356-e9c8d280-95f5-11ea-98e1-8635510b9a1b.png">
