### PR TITLE
feat: removing financial assistance checkbox from service page

### DIFF
--- a/src/containers/ServiceTypeForm.js
+++ b/src/containers/ServiceTypeForm.js
@@ -27,7 +27,6 @@ const styles = {
   }),
   showNote: css({
     display: 'block',
-    marginTop: Space.S30,
   }),
   link: css({
     alignItems: 'baseline',
@@ -57,7 +56,6 @@ export const ServiceTypeForm = ({
   const [fields, setFields] = useState({
     kind: undefined,
     urgency: undefined,
-    needsFinances: false,
     organization: '',
     zip: '',
   });
@@ -257,16 +255,9 @@ export const ServiceTypeForm = ({
       type: formFieldTypes.INPUT_DROPDOWN,
       value: fields.urgency,
     },
-    {
-      customOnChange: handleFieldChange('needsFinances'),
-      label: t('service.selectType.form.needsFinances'),
-      name: 'needsFinances',
-      type: formFieldTypes.INPUT_CHECKBOX,
-      value: fields.needsFinances,
-    },
   ];
 
-  const { needsFinances, ...requiredFields } = fields;
+  const { ...requiredFields } = fields;
 
   return (
     <FormBuilder


### PR DESCRIPTION
* Removing the financial assistance checkbox from the service type page.
* Update Note padding now that checkbox is gone.

![Large GIF (374x810)](https://user-images.githubusercontent.com/1128500/82481829-c638d880-9a8a-11ea-9f97-9aa8b34c3d91.gif)
