### PR TITLE
feat: updates to partner info on learn more page

### DIFF
--- a/src/components/LearnMore/FAQ.js
+++ b/src/components/LearnMore/FAQ.js
@@ -24,6 +24,9 @@ export const FAQ = () => {
   const nycCovidCare = `[${t(
     'learnMore.about.partners.partner3.title',
   )}](http://${t('learnMore.about.partners.partner1.url')})`;
+  const invisibleHands = `[${t(
+    'learnMore.about.partners.partner4.title',
+  )}](http://${t('learnMore.about.partners.partner4.url')})`;
 
   return (
     <div css={styles.container}>
@@ -64,6 +67,7 @@ export const FAQ = () => {
             mutualAid,
             workersNeedChildcare,
             nycCovidCare,
+            invisibleHands,
           })}
         />
       </Text>

--- a/src/components/LearnMore/LearnMore.styles.js
+++ b/src/components/LearnMore/LearnMore.styles.js
@@ -27,6 +27,7 @@ export const styles = {
 
     a: {
       color: Color.PRIMARY,
+      textDecoration: 'none',
     },
   }),
   organization: css({

--- a/src/components/LearnMore/Partners.js
+++ b/src/components/LearnMore/Partners.js
@@ -54,6 +54,20 @@ export const Partners = () => {
           </Anchor>
         </Text>
       </div>
+      <div css={styles.organization}>
+        <Text as="h4" css={styles.faqSubtitle} type={TEXT_TYPE.HEADER_6}>
+          {t('learnMore.about.partners.partner4.title')}
+        </Text>
+        <Text as="p" type={TEXT_TYPE.BODY_2}>
+          <Anchor
+            href={`http://${t('learnMore.about.partners.partner4.url')}`}
+            as={anchorTypes.A}
+            isExternalLink
+          >
+            {t('learnMore.about.partners.partner4.url')}
+          </Anchor>
+        </Text>
+      </div>
     </div>
   );
 };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -66,9 +66,9 @@
         "question1": "Who can request help?",
         "answer1": "Our focus is on helping anyone working for a NYC medical facility or EMS treating people suffering from COVID-19. Support staff, nurses, and doctors are all encouraged to make requests.",
         "question2": "How can I be sure that my request and information stay private?",
-        "answer2": "We share your data securely on a per-request basis with only the service organization that will fulfill your request. [Privacy policy]({{url}})",
+        "answer2": "We share your data securely on a per-request basis with only the service organization that will fulfill your request. For more details, please see our [Privacy policy]({{url}})",
         "question3": "Does Help Supply provide the volunteer services?",
-        "answer3": "No. We gather requests and then route them to the most appropriate of our partner organizations to provide volunteers to fulfill them. Our current partners include {{mutualAid}}, {{workersNeedChildcare}}, and {{nycCovidCare}}.",
+        "answer3": "No. We gather requests and then route them to the most appropriate of our partner organizations to provide volunteers to fulfill them. Our current partners include {{mutualAid}}, {{workersNeedChildcare}}, {{nycCovidCare}}, and {{invisibleHands}}.",
         "question4": "How long will I have to wait for help?",
         "answer4": "Many people are in difficult situations, and the volume of requests is high. Our partners will contact you as soon as they can.",
         "question5": "Will you expand to other cities besides NYC?",
@@ -101,6 +101,11 @@
             "title": "NYC COVID Care Network",
             "content": "Content",
             "url": "nyccovidcare.org"
+          },
+          "partner4": {
+            "title": "Invisible Hands",
+            "content": "Content",
+            "url": "invisiblehandsdeliver.org/"
           }
         }
       },

--- a/src/pages/learn_more.js
+++ b/src/pages/learn_more.js
@@ -6,7 +6,7 @@ import { LearnMore as LearnMoreComponent } from 'components/LearnMore';
 
 function LearnMore() {
   return (
-    <Page hasBackButton={true}>
+    <Page hasBackButton={false}>
       <LearnMoreComponent />
     </Page>
   );


### PR DESCRIPTION
* Added 'Invisible Hands' to 'Does Help Supply provide the volunteer services?' section of FAQ.
* Added 'Invisible Hands' to 'Our Partners' section of 'About HS'.
* ~Noticed `learn-more` pages has a backButton on desktop and no backButton on mobile. Extended `hasBackButton` prop to include mobile and desktop declarations.~ Took out backButton on 'learn-more' pages.
* Updated `text-underline: none` on FAQ links.

<img width="373" alt="Screenshot 2020-05-20 11 56 13" src="https://user-images.githubusercontent.com/1128500/82486585-f5067d00-9a91-11ea-8242-428262c43746.png">

<img width="376" alt="Screenshot 2020-05-20 11 56 40" src="https://user-images.githubusercontent.com/1128500/82486595-f768d700-9a91-11ea-9db5-c000ebbb6a27.png">
