### PR TITLE
fix: remove trailing slash from new partner url

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -105,7 +105,7 @@
           "partner4": {
             "title": "Invisible Hands",
             "content": "Content",
-            "url": "invisiblehandsdeliver.org/"
+            "url": "invisiblehandsdeliver.org"
           }
         }
       },


### PR DESCRIPTION
* Remove trailing slash from Invisible Hands partner url.

old ↓
<img width="271" alt="Screenshot 2020-05-20 13 23 25" src="https://user-images.githubusercontent.com/1128500/82493711-41a38580-9a9d-11ea-8fe7-46b3eeeeefe5.png">

new ↓
<img width="233" alt="Screenshot 2020-05-20 13 23 31" src="https://user-images.githubusercontent.com/1128500/82493716-4405df80-9a9d-11ea-913f-98592bc778fd.png">
